### PR TITLE
Detect and surface auth/network errors from streamrip output

### DIFF
--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -148,6 +148,43 @@ def toml_escape(value):
     return value.replace("\\", "\\\\").replace('"', '\\"')
 
 
+def parse_streamrip_error(output: str):
+    """Return a user-friendly message if output matches a known streamrip error, else None."""
+    lo = output.lower()
+
+    if any(p in lo for p in [
+        "authenticationerror", "authentication failed", "authentication error",
+        "login failed", "invalid credentials", "incorrect password",
+        "invalid email", "wrong password", "unauthorized",
+        "could not authenticate", "not authenticated",
+    ]):
+        return "❌  Authentication failed — check your credentials in accounts.json."
+
+    if any(p in lo for p in ["invalid arl", "arl expired", "arl is invalid", "bad arl"]):
+        return "❌  Deezer ARL token is invalid or expired — update it in accounts.json."
+
+    if any(p in lo for p in [
+        "invalid token", "token expired", "token is invalid", "token has expired",
+    ]):
+        return "❌  Access token is invalid or expired — re-authenticate your account."
+
+    if any(p in lo for p in [
+        "track not found", "album not found", "resource not found",
+        "resourcenotfounderror", "not available in your region", "does not exist",
+    ]):
+        return "❌  Content not found — the track or album may be unavailable."
+
+    if any(p in lo for p in [
+        "connectionerror", "connection refused", "network error",
+        "sslerror", "ssl error", "name or service not known",
+        "nodename nor servname provided", "errno 111", "errno 110",
+        "timed out", "read timeout", "connection timed out",
+    ]):
+        return "❌  Network error — check your internet connection and try again."
+
+    return None
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 #  AurynApp — charge l'UI depuis Auryn.ui
 # ─────────────────────────────────────────────────────────────────────────────
@@ -215,10 +252,11 @@ class AurynApp:
         }
 
         # ── État interne ──
-        self._process      = None
-        self._dest_folder  = os.path.expanduser("~/Music")
-        self._track_done   = 0
-        self._total_tracks = 0
+        self._process          = None
+        self._dest_folder      = os.path.expanduser("~/Music")
+        self._track_done       = 0
+        self._total_tracks     = 0
+        self._last_known_error = None
 
         # ── Forcer can-focus sur les widgets interactifs ──
         self.url_entry.set_can_focus(True)
@@ -324,8 +362,9 @@ class AurynApp:
         self.progress_bar.set_fraction(0)
         self._clear_log()
         self._reset_meta()
-        self._track_done   = 0
-        self._total_tracks = 0
+        self._track_done       = 0
+        self._total_tracks     = 0
+        self._last_known_error = None
         self._set_status("⏳   Fetching album info...", "info")
         self._set_lyrics('<span foreground="#444444"><i>Lyrics will appear here during download...</i></span>')
         quality = self._get_quality()
@@ -685,6 +724,11 @@ class AurynApp:
         lo = line.lower()
         if any(w in lo for w in ["error", "failed", "exception", "traceback"]):
             tag = "error"
+            friendly = parse_streamrip_error(line)
+            if friendly:
+                self._set_status(friendly, "error")
+                if not self._last_known_error:
+                    self._last_known_error = friendly
         elif any(w in lo for w in ["done", "complete", "finished", "success"]):
             tag = "ok"
             self.progress_bar.set_fraction(1.0)
@@ -767,7 +811,8 @@ class AurynApp:
         else:
             code = self._process.returncode if self._process else -1
             if code != -15:
-                self._set_status("❌  Download failed — check the log.", "error")
+                status_msg = self._last_known_error or "❌  Download failed — check the log."
+                self._set_status(status_msg, "error")
                 self._log("\n❌  Download failed.\n", "error")
         self.btn_download.set_sensitive(True)
         self.btn_stop.hide()


### PR DESCRIPTION
## Summary

- Adds `parse_streamrip_error(output: str) -> str | None` — a standalone helper that matches known streamrip error patterns (auth failures, invalid ARL/tokens, content not found, network errors) and returns a concise, user-friendly message
- Integrates it in `_parse_line()`: when a line is tagged as an error, the helper is called; on a match the status bar is updated immediately and the message is stored in `self._last_known_error`
- Integrates it in `_finish()`: on download failure, uses `_last_known_error` as the final status instead of the generic fallback — falls back to `"❌  Download failed — check the log."` when no known pattern was seen

## Error categories detected

| Category | Example patterns |
|---|---|
| Authentication | `login failed`, `unauthorized`, `authenticationerror`, `invalid credentials` |
| Deezer ARL | `invalid arl`, `arl expired`, `bad arl` |
| Access token | `token expired`, `invalid token`, `token has expired` |
| Content not found | `track not found`, `resourcenotfounderror`, `not available in your region` |
| Network | `connectionerror`, `timed out`, `ssl error`, `connection refused` |

## Verification

- `python -m py_compile src/Auryn.py` — passes clean
- Normal lines (`Downloading …`, `Track Download Done`, info lines) → `parse_streamrip_error` returns `None`, status bar unchanged
- All five error categories → correct friendly message returned
- Unknown error lines → `None` (generic fallback preserved)
- Only `src/Auryn.py` changed — no README, LICENSE, or packaging files touched

## Test plan

- [ ] Start a download with valid credentials → success flow unchanged
- [ ] Enter wrong Qobuz password → status bar shows auth error message
- [ ] Set an expired Deezer ARL → status bar shows ARL message
- [ ] Use a URL for a region-locked track → status bar shows content-not-found message
- [ ] Disconnect network mid-download → status bar shows network error message
- [ ] In all cases confirm raw log lines are still preserved in the log view

https://claude.ai/code/session_015swnjjwwseoeTRJMUSnVGH

---
_Generated by [Claude Code](https://claude.ai/code/session_015swnjjwwseoeTRJMUSnVGH)_