### PR TITLE
feat: credentials dialog shell (issue #56)

### DIFF
--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -901,7 +901,7 @@ class AurynApp:
         separator()
 
         section("Tidal")
-        field("Token", "not yet supported", sensitive=False)
+        field("Token", "paste your token here")
 
         content.pack_start(grid, True, True, 0)
         dlg.show_all()


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Credentials dialog opens from the toolbar `Credentials` button
- Three sections: **Qobuz** (email + password), **Deezer** (ARL token), **Tidal** (token)
- All fields are enabled and ready for input — Tidal field was previously disabled with "not yet supported", now consistent with the other sections
- **Save** and **Cancel** both close the dialog; no saving or validation logic added

## Test plan

- [ ] Click **Credentials** in the toolbar — dialog opens
- [ ] All three sections (Qobuz, Deezer, Tidal) are visible and fields are editable
- [ ] Password field masks input
- [ ] Save closes the dialog
- [ ] Cancel closes the dialog
- [ ] No changes to download or streamrip logic

Closes #56

https://claude.ai/code/session_01Vvgr3npwutyuD6vjb4U93Q
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vvgr3npwutyuD6vjb4U93Q)_