### PR TITLE
feat: save credentials to accounts.json on dialog Save (issue #58)

### DIFF
--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -935,7 +935,7 @@ class AurynApp:
         dlg.show_all()
         resp = dlg.run()
         if resp == Gtk.ResponseType.OK:
-            acc_data = {}
+            acc_data = dict(acc)
             q_email = qobuz_email.get_text().strip()
             q_pass  = qobuz_pass.get_text().strip()
             if q_email or q_pass:

--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -933,7 +933,22 @@ class AurynApp:
 
         content.pack_start(grid, True, True, 0)
         dlg.show_all()
-        dlg.run()
+        resp = dlg.run()
+        if resp == Gtk.ResponseType.OK:
+            acc_data = {}
+            q_email = qobuz_email.get_text().strip()
+            q_pass  = qobuz_pass.get_text().strip()
+            if q_email or q_pass:
+                acc_data["qobuz"] = {"email": q_email, "password": q_pass}
+            d_arl = deezer_arl.get_text().strip()
+            if d_arl:
+                acc_data["deezer"] = {"arl": d_arl}
+            t_token = tidal_token.get_text().strip()
+            if t_token:
+                acc_data["tidal"] = {"token": t_token}
+            os.makedirs(os.path.dirname(acc_path), exist_ok=True)
+            with open(acc_path, "w") as f:
+                json.dump(acc_data, f, indent=2)
         dlg.destroy()
 
     def _show_about(self, *_):


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Captures the return value of `dlg.run()` in the credentials dialog
- On Save (`Gtk.ResponseType.OK`), reads and strips values from the Qobuz, Deezer, and Tidal fields
- Skips a service block entirely if all its fields are empty
- Creates `~/.config/Auryn/` if it does not exist (`os.makedirs(..., exist_ok=True)`)
- Overwrites `~/.config/Auryn/accounts.json` with structured JSON matching the format the backend already reads

## Test plan

- [ ] Open the credentials dialog, fill in Qobuz email + password, click Save — verify `~/.config/Auryn/accounts.json` is created with a `qobuz` block only
- [ ] Fill in all three services, click Save — verify all three blocks appear in the file
- [ ] Leave all fields empty, click Save — verify the file is written as `{}`
- [ ] Click Cancel — verify the file is not written/modified
- [ ] Reopen the dialog — verify fields are pre-populated from the saved file (existing read logic in #57)
- [ ] Attempt a download — verify credentials are applied automatically (existing backend handles this)

Closes #58

https://claude.ai/code/session_0113xN29XZPukkHqUCkgYLcy
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0113xN29XZPukkHqUCkgYLcy)_