### PR TITLE
fix: preserve existing accounts.json keys when saving credentials (#58)

### DIFF
--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -905,7 +905,7 @@ class AurynApp:
         acc_path = os.path.expanduser("~/.config/Auryn/accounts.json")
         if os.path.exists(acc_path):
             try:
-                with open(acc_path, 'r') as f:
+                with open(acc_path, 'r', encoding="utf-8") as f:
                     acc = json.load(f)
             except Exception:
                 pass
@@ -939,15 +939,22 @@ class AurynApp:
             q_email = qobuz_email.get_text().strip()
             q_pass  = qobuz_pass.get_text().strip()
             if q_email or q_pass:
-                acc_data["qobuz"] = {"email": q_email, "password": q_pass}
+                if not isinstance(acc_data.get("qobuz"), dict):
+                    acc_data["qobuz"] = {}
+                acc_data["qobuz"]["email"] = q_email
+                acc_data["qobuz"]["password"] = q_pass
             d_arl = deezer_arl.get_text().strip()
             if d_arl:
-                acc_data["deezer"] = {"arl": d_arl}
+                if not isinstance(acc_data.get("deezer"), dict):
+                    acc_data["deezer"] = {}
+                acc_data["deezer"]["arl"] = d_arl
             t_token = tidal_token.get_text().strip()
             if t_token:
-                acc_data["tidal"] = {"token": t_token}
+                if not isinstance(acc_data.get("tidal"), dict):
+                    acc_data["tidal"] = {}
+                acc_data["tidal"]["token"] = t_token
             os.makedirs(os.path.dirname(acc_path), exist_ok=True)
-            with open(acc_path, "w") as f:
+            with open(acc_path, "w", encoding="utf-8") as f:
                 json.dump(acc_data, f, indent=2)
         dlg.destroy()
 


### PR DESCRIPTION
## Summary

Fixes #58 — the credential save logic previously replaced entire provider sub-dicts, which could discard unknown or future keys.

- Merge individual fields into existing `qobuz` / `deezer` / `tidal` sub-dicts instead of replacing the whole object
- Top-level unknown keys were already preserved via `dict(acc)`; sub-key preservation is the new guarantee
- Add `encoding="utf-8"` to both the read and write file opens
- Missing or corrupted `accounts.json` still falls back safely via `except Exception: pass`
- No UI behavior changed

## Test plan

- [ ] Open credentials dialog with an existing `accounts.json` that contains an unknown top-level key (e.g. `"future_key": "value"`) — confirm it survives a save
- [ ] Open credentials dialog with a provider sub-dict that has an extra field (e.g. `"qobuz": {"email": "...", "password": "...", "extra": "x"}`) — confirm `extra` is preserved after save
- [ ] Save credentials normally and confirm qobuz / deezer / tidal values are written correctly
- [ ] Delete or corrupt `accounts.json` and confirm the dialog still opens without crashing

https://claude.ai/code/session_017MFFyxm3jq3sTwpYNZxiNo

---
_Generated by [Claude Code](https://claude.ai/code/session_017MFFyxm3jq3sTwpYNZxiNo)_