### PR TITLE
feat: guide users to credentials setup during first run

### DIFF
--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -497,6 +497,13 @@ class AurynApp:
             self._log("⚠  Startup checks found issues:\n", "info")
             for issue in issues:
                 self._log(f"   • {issue}\n", "info")
+
+        acc_path = os.path.expanduser("~/.config/Auryn/accounts.json")
+        if not os.path.exists(acc_path):
+            self._log(
+                "ℹ  No credentials saved yet — click the Credentials button to set up your accounts.\n",
+                "info",
+            )
         return False
 
     def _show_setup_wizard(self, *_):
@@ -508,6 +515,12 @@ class AurynApp:
             body = "Issues detected:\n- " + "\n- ".join(issues)
             status = "⚠ Setup needs attention"
 
+        acc_path = os.path.expanduser("~/.config/Auryn/accounts.json")
+        if os.path.exists(acc_path):
+            body += "\n\n✅ Credentials saved."
+        else:
+            body += "\n\n⚠ No credentials saved yet — click \"Set up Accounts\" to enter your service credentials."
+
         dlg = Gtk.MessageDialog(
             transient_for=self.window,
             flags=0,
@@ -518,6 +531,7 @@ class AurynApp:
         dlg.format_secondary_text(body)
         if not ok:
             dlg.add_button("Auto-fix", 1)
+        dlg.add_button("Set up Accounts", 2)
         dlg.add_button("Close", Gtk.ResponseType.CLOSE)
         response = dlg.run()
         dlg.destroy()
@@ -532,6 +546,9 @@ class AurynApp:
                 self._log("❌  Setup auto-fix could not solve all issues:\n", "error")
                 for issue in fixed_issues:
                     self._log(f"   • {issue}\n", "error")
+        elif response == 2:
+            self._show_credentials_dialog()
+            self._show_setup_wizard()
 
     def _update_config(self, cfg, pattern, replacement, first_only=False):
         if not os.path.exists(cfg):


### PR DESCRIPTION
## Summary

- On startup, `_first_run_health_check` now logs a hint to click the **Credentials** button when `accounts.json` is absent, so new users are not left wondering where to enter their service credentials.
- `_show_setup_wizard` now appends a credentials status line to the dialog body (✅ saved / ⚠ missing) and adds a **"Set up Accounts"** button. Clicking it opens the existing credentials dialog; when that dialog is closed, the setup wizard re-opens so the user can see the updated status.
- All existing preflight checks (`_run_preflight_checks`) are unchanged.
- No credential-saving or download logic was modified.

## Where the first-run/setup message was changed

| Function | File | Lines |
|---|---|---|
| `_first_run_health_check` | `src/Auryn.py` | ~501-507 |
| `_show_setup_wizard` | `src/Auryn.py` | ~518-551 |

## Test plan

- [ ] Launch Auryn without `~/.config/Auryn/accounts.json` → log view shows credentials hint
- [ ] Launch Auryn with `accounts.json` present → no hint logged
- [ ] Open Setup dialog without credentials → body shows ⚠ message and "Set up Accounts" button is present
- [ ] Open Setup dialog with credentials saved → body shows ✅ message
- [ ] Click "Set up Accounts" → credentials dialog opens; on close, Setup dialog re-opens
- [ ] "Auto-fix" and "Close" buttons still work as before
- [ ] Download flow unaffected

Closes #53

https://claude.ai/code/session_01LoEygws93Q6VHFUy3SN5Rt

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoEygws93Q6VHFUy3SN5Rt)_