### PR TITLE
Improve streamrip executable detection for Windows

### DIFF
--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -463,16 +463,42 @@ class AurynApp:
     # ── Lancement streamrip ───────────────────────────────────────────────────
 
     def _find_rip_path(self):
-        for candidate in [
-            os.path.expanduser("~/.local/bin/rip"),
-            "/usr/local/bin/rip",
-            "/usr/bin/rip",
-        ]:
-            if os.path.isfile(candidate):
-                return candidate
         found = shutil.which("rip")
         if found:
             return found
+
+        if IS_WINDOWS:
+            candidates = []
+            appdata = os.environ.get("APPDATA", "")
+            localappdata = os.environ.get("LOCALAPPDATA", "")
+            userprofile = os.environ.get("USERPROFILE", "")
+
+            if appdata:
+                candidates.append(os.path.join(appdata, "Python", "Scripts", "rip.exe"))
+                candidates.append(os.path.join(appdata, "pipx", "venvs", "streamrip", "Scripts", "rip.exe"))
+            if localappdata:
+                python_root = os.path.join(localappdata, "Programs", "Python")
+                if os.path.isdir(python_root):
+                    for entry in sorted(os.listdir(python_root), reverse=True):
+                        if entry.startswith("Python"):
+                            candidates.append(
+                                os.path.join(python_root, entry, "Scripts", "rip.exe")
+                            )
+            if userprofile:
+                candidates.append(os.path.join(userprofile, ".local", "bin", "rip.exe"))
+
+            for candidate in candidates:
+                if os.path.isfile(candidate):
+                    return candidate
+        else:
+            for candidate in [
+                os.path.expanduser("~/.local/bin/rip"),
+                "/usr/local/bin/rip",
+                "/usr/bin/rip",
+            ]:
+                if os.path.isfile(candidate):
+                    return candidate
+
         return None
 
     def _check_dest_writable(self):


### PR DESCRIPTION
## Summary
Enhanced the `_find_rip_path()` method to provide better cross-platform support for locating the streamrip executable, with particular improvements for Windows systems.

## Key Changes
- Refactored executable search logic to use `shutil.which()` as the primary method (works across all platforms)
- Added Windows-specific fallback paths that check common installation locations:
  - APPDATA Python Scripts directory
  - APPDATA pipx virtual environment directory
  - LOCALAPPDATA Python installations (with reverse-sorted version detection)
  - USERPROFILE .local/bin directory
- Moved Unix/Linux-specific paths into a dedicated else block for clarity
- Improved robustness by checking for Python installation directories dynamically rather than hardcoding paths

## Implementation Details
- Windows paths now properly use environment variables (APPDATA, LOCALAPPDATA, USERPROFILE) for better compatibility across different system configurations
- Python version detection on Windows iterates through installed versions in reverse order to prefer newer versions
- Maintains backward compatibility with existing Unix/Linux path detection
- Returns `None` if executable cannot be found through any method

https://claude.ai/code/session_01KtjxdmRjNs9umcTJDm6BiW