### PR TITLE
Update GTK dependency requirement from 4 to 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Windows support is experimental. The app has a cross-platform path layer and an 
 
 - Python 3.11+
 - [streamrip](https://github.com/nathom/streamrip) installed and available on `PATH` as `rip`
-- GTK 4 and PyGObject installed through a supported Windows method (for example MSYS2, or another PyGObject-compatible environment)
+- GTK 3 and PyGObject installed through a supported Windows method (for example MSYS2, or another PyGObject-compatible environment)
 
 ### Basic setup
 


### PR DESCRIPTION
## Summary
Updated the Windows setup documentation to reflect GTK 3 as the required version instead of GTK 4.

## Changes
- Updated README.md Windows dependencies section to specify GTK 3 instead of GTK 4
- This aligns the documented requirements with the actual supported GTK version for the application

## Details
The change corrects the dependency documentation for Windows users setting up the application. GTK 3 is the correct version requirement for PyGObject compatibility in the supported Windows environments (MSYS2, etc.).

https://claude.ai/code/session_01R3Xf2o5xhFJizqJNyMPdxX