### PR TITLE
Add Windows packaging with PyInstaller --onedir build

### DIFF
--- a/packaging/windows/Auryn.spec
+++ b/packaging/windows/Auryn.spec
@@ -1,0 +1,157 @@
+# -*- mode: python ; coding: utf-8 -*-
+#
+# PyInstaller spec for Auryn — Windows portable --onedir build.
+#
+# This spec is intended to be run from an MSYS2 MINGW64 shell on Windows,
+# with the GTK3 runtime, PyGObject, and PyInstaller already installed there
+# (see packaging/windows/README.md). It will not produce a working bundle
+# from a plain pip-on-Windows environment.
+#
+# Output: dist/Auryn/  (a portable folder; zip it to distribute)
+
+import os
+import sys
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_submodules
+
+block_cipher = None
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+# The spec is invoked from the repository root by build.ps1, so SPECPATH
+# resolves to packaging/windows/. Compute REPO_ROOT relative to it.
+SPEC_DIR = Path(SPECPATH).resolve()
+REPO_ROOT = SPEC_DIR.parent.parent
+SRC_DIR = REPO_ROOT / "src"
+ASSETS_DIR = REPO_ROOT / "assets"
+
+# MSYS2 MINGW64 prefix. Override with AURYN_MINGW_PREFIX if your install
+# is non-standard (e.g. C:\\msys64\\mingw64).
+MINGW_PREFIX = Path(os.environ.get("AURYN_MINGW_PREFIX", "C:/msys64/mingw64"))
+
+# ---------------------------------------------------------------------------
+# Optional icon
+# ---------------------------------------------------------------------------
+ICON_PATH = ASSETS_DIR / "Auryn.ico"
+icon_arg = str(ICON_PATH) if ICON_PATH.exists() else None
+
+# ---------------------------------------------------------------------------
+# Data files shipped from the repo
+# ---------------------------------------------------------------------------
+datas = [
+    (str(SRC_DIR / "Auryn.ui"), "."),
+    (str(ASSETS_DIR / "Auryn.svg"), "assets"),
+    (str(ASSETS_DIR / "Auryn_16.png"), "assets"),
+    (str(ASSETS_DIR / "Auryn_32.png"), "assets"),
+    (str(ASSETS_DIR / "Auryn_48.png"), "assets"),
+    (str(ASSETS_DIR / "Auryn_256.png"), "assets"),
+]
+
+# ---------------------------------------------------------------------------
+# GTK3 runtime data trees from MSYS2 MINGW64
+# ---------------------------------------------------------------------------
+# PyInstaller's automatic analysis does NOT discover any of this. Each entry
+# below is something GTK loads at runtime by relative path; missing any of
+# them produces a degraded UI (missing icons, wrong fonts, blank widgets)
+# without an obvious error.
+gtk_data_trees = [
+    # GObject introspection typelibs.
+    (MINGW_PREFIX / "lib" / "girepository-1.0", "lib/girepository-1.0"),
+    # gdk-pixbuf image loaders + their cache.
+    (MINGW_PREFIX / "lib" / "gdk-pixbuf-2.0", "lib/gdk-pixbuf-2.0"),
+    # Compiled GSettings schemas.
+    (MINGW_PREFIX / "share" / "glib-2.0" / "schemas", "share/glib-2.0/schemas"),
+    # Adwaita + hicolor icon themes (do not omit; Gtk falls back silently).
+    (MINGW_PREFIX / "share" / "icons" / "Adwaita", "share/icons/Adwaita"),
+    (MINGW_PREFIX / "share" / "icons" / "hicolor", "share/icons/hicolor"),
+    # Locale data for GTK / GLib message catalogs (small but expected).
+    (MINGW_PREFIX / "share" / "locale", "share/locale"),
+    # Fontconfig defaults.
+    (MINGW_PREFIX / "etc" / "fonts", "etc/fonts"),
+]
+
+for src, dest in gtk_data_trees:
+    if src.exists():
+        datas.append((str(src), dest))
+    else:
+        # Fail loud on the build host rather than ship a broken bundle.
+        raise SystemExit(
+            f"[Auryn.spec] Required GTK runtime path not found: {src}\n"
+            f"Make sure mingw-w64-x86_64-gtk3 is installed and "
+            f"AURYN_MINGW_PREFIX points at your MSYS2 MINGW64 root."
+        )
+
+# ---------------------------------------------------------------------------
+# Hidden imports
+# ---------------------------------------------------------------------------
+# PyGObject pulls modules by name through gi; help PyInstaller find them.
+hiddenimports = []
+hiddenimports += collect_submodules("gi")
+hiddenimports += [
+    "gi",
+    "gi.repository.Gtk",
+    "gi.repository.Gdk",
+    "gi.repository.GLib",
+    "gi.repository.GObject",
+    "gi.repository.Gio",
+    "gi.repository.GdkPixbuf",
+    "gi.repository.Pango",
+]
+
+# ---------------------------------------------------------------------------
+# Build
+# ---------------------------------------------------------------------------
+a = Analysis(
+    [str(SRC_DIR / "Auryn.py")],
+    pathex=[str(SRC_DIR)],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[str(SPEC_DIR / "runtime_hook_gtk.py")],
+    excludes=[
+        # Trim obvious unused stdlib pieces. Conservative; expand later if
+        # bundle size becomes a real problem.
+        "tkinter",
+        "test",
+        "unittest",
+    ],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="Auryn",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=False,
+    disable_windowed_traceback=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=icon_arg,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name="Auryn",
+)

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -1,0 +1,125 @@
+# Windows packaging — manual `--onedir` build
+
+This directory contains the **first** Windows packaging setup for Auryn:
+a PyInstaller spec, a runtime hook for GTK3, and a PowerShell helper
+script for running the build by hand on a Windows machine.
+
+> **Status: experimental.** Windows packaging is not finished. There is no
+> installer, no CI job, no code signing, and no auto-update. The only
+> thing this directory currently does is let a developer produce a
+> portable folder locally to smoke-test the approach.
+
+See [`docs/windows-packaging.md`](../../docs/windows-packaging.md) for the
+overall plan and the reasoning behind these choices (why `--onedir`,
+why MSYS2, why streamrip stays external, etc.).
+
+## What this produces
+
+- A folder at `dist/Auryn/` containing `Auryn.exe` plus the bundled GTK3
+  runtime, typelibs, icon themes, and Auryn's own data files.
+- That folder is intended to be zipped and copied to another Windows
+  machine. It runs in place; it does not need to be installed.
+
+It does **not** produce:
+
+- a single-file `.exe`,
+- an Inno Setup / MSI installer,
+- a signed binary,
+- a bundled `rip.exe` or streamrip credentials.
+
+`rip` (streamrip) remains an external dependency that the user installs
+separately. Auryn discovers it via PATH at runtime.
+
+## Build host requirements
+
+The build must run from an **MSYS2 MINGW64** shell on Windows. A plain
+pip-on-Windows environment cannot produce a working GTK3 bundle today.
+
+Inside MSYS2, install:
+
+```sh
+pacman -S \
+    mingw-w64-x86_64-gtk3 \
+    mingw-w64-x86_64-python \
+    mingw-w64-x86_64-python-gobject \
+    mingw-w64-x86_64-python-pyinstaller
+```
+
+(`mingw-w64-x86_64-python-pyinstaller` may be installed via `pip` into
+the MINGW64 Python instead, if the pacman package lags behind.)
+
+Auryn's own Python imports — `gi`, `Gtk`, `Gdk`, `GdkPixbuf`, `Pango` —
+all come from the `mingw-w64-x86_64-python-gobject` package. There is
+intentionally no `requirements.txt` here yet; that is a separate cleanup.
+
+## Running the build
+
+From the MSYS2 MINGW64 shell, in the repo root:
+
+```sh
+# Option A: invoke PyInstaller directly.
+AURYN_MINGW_PREFIX=/mingw64 pyinstaller --noconfirm --clean \
+    packaging/windows/Auryn.spec
+
+# Option B: use the PowerShell helper (from PowerShell, not bash).
+pwsh -File packaging/windows/build.ps1 -Clean
+```
+
+Either way the result lands in `dist/Auryn/`. Launch `dist\Auryn\Auryn.exe`
+to smoke-test.
+
+The spec resolves the GTK runtime from `AURYN_MINGW_PREFIX` (default
+`C:/msys64/mingw64`). Override it if your MSYS2 install is somewhere
+else.
+
+## What the spec ships
+
+PyInstaller's automatic dependency analysis does **not** discover the
+GTK runtime. The spec copies these explicitly out of MINGW64:
+
+- `lib/girepository-1.0/` — typelibs for Gtk, Gdk, GLib, GObject, Gio,
+  GdkPixbuf, Pango, etc.
+- `lib/gdk-pixbuf-2.0/` — image loader DLLs and `loaders.cache`.
+- `share/glib-2.0/schemas/` — compiled GSettings schemas.
+- `share/icons/Adwaita` and `share/icons/hicolor` — icon themes.
+- `share/locale/` — GLib / GTK message catalogs.
+- `etc/fonts/` — Fontconfig defaults.
+
+It also ships `src/Auryn.ui` and the SVG/PNG assets.
+
+`runtime_hook_gtk.py` runs before Auryn's own code and points
+`GI_TYPELIB_PATH`, `GDK_PIXBUF_MODULE_FILE`, `GDK_PIXBUF_MODULEDIR`,
+`XDG_DATA_DIRS`, and `FONTCONFIG_PATH` at the bundled tree.
+
+## Icon
+
+If `assets/Auryn.ico` exists at build time the spec uses it as the
+executable icon. If not, the build still succeeds — `Auryn.exe` just
+gets the default PyInstaller icon. Generating a multi-resolution `.ico`
+from `assets/Auryn.svg` is a separate task and is not part of this PR.
+
+## Smoke-testing
+
+Always test the bundle on a **clean** Windows VM with no prior GTK,
+Python, or MSYS2 install. A bundle that "works" only because the
+developer's machine already has GTK installed system-wide is the
+classic GTK-on-Windows packaging trap.
+
+Things to verify:
+
+- `Auryn.exe` launches without a console error window.
+- The main window appears with the dark theme and the correct icons
+  (a missing gdk-pixbuf cache shows up here as missing icons).
+- File pickers open without crashing.
+- Status messages render with the right fonts (a broken fontconfig
+  setup shows up here).
+- Auryn correctly reports whether `rip.exe` is on PATH; downloads work
+  if it is.
+
+## Out of scope for this directory
+
+- GitHub Actions / CI builds. Tracked separately.
+- Inno Setup installer. Tracked separately.
+- Code signing. Requires a certificate; tracked separately.
+- Bundling streamrip / `rip.exe`. Intentionally not done — see
+  `docs/windows-packaging.md`.

--- a/packaging/windows/build.ps1
+++ b/packaging/windows/build.ps1
@@ -1,0 +1,88 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+    Build a portable Windows --onedir bundle of Auryn with PyInstaller.
+
+.DESCRIPTION
+    Manual local build script. Runs PyInstaller against
+    packaging/windows/Auryn.spec and leaves the result in dist/Auryn/.
+
+    This script must be invoked from an MSYS2 MINGW64 shell (or a
+    PowerShell where the MSYS2 MINGW64 bin dir is first on PATH).
+    A plain pip-on-Windows environment will not produce a working bundle:
+    GTK3 / PyGObject need the MSYS2 GTK runtime to be present at build
+    time so the spec can copy it into the bundle.
+
+    No installer is produced. No CI is involved. No code signing.
+
+.PARAMETER MingwPrefix
+    Path to the MSYS2 MINGW64 root. Defaults to C:\msys64\mingw64.
+    Forwarded to the spec via the AURYN_MINGW_PREFIX env var.
+
+.PARAMETER Clean
+    Delete build/ and dist/ before building.
+
+.EXAMPLE
+    # From the MSYS2 MINGW64 shell (or equivalent):
+    pwsh -File packaging/windows/build.ps1 -Clean
+#>
+[CmdletBinding()]
+param(
+    [string]$MingwPrefix = "C:\msys64\mingw64",
+    [switch]$Clean
+)
+
+$ErrorActionPreference = "Stop"
+
+# Resolve repo root from this script's location.
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot  = Resolve-Path (Join-Path $ScriptDir "..\..")
+$SpecFile  = Join-Path $ScriptDir "Auryn.spec"
+
+Write-Host "Auryn Windows packaging (manual --onedir build)" -ForegroundColor Cyan
+Write-Host "  repo root   : $RepoRoot"
+Write-Host "  spec file   : $SpecFile"
+Write-Host "  MINGW64     : $MingwPrefix"
+Write-Host ""
+
+if (-not (Test-Path $MingwPrefix)) {
+    throw "MSYS2 MINGW64 prefix not found at '$MingwPrefix'. Install MSYS2 and the mingw-w64-x86_64-gtk3 / -python / -python-gobject packages, or pass -MingwPrefix."
+}
+
+if (-not (Get-Command pyinstaller -ErrorAction SilentlyContinue)) {
+    throw "pyinstaller not found on PATH. Install it inside the MSYS2 MINGW64 shell: pacman -S mingw-w64-x86_64-python-pyinstaller (or pip install pyinstaller into the MINGW64 python)."
+}
+
+Push-Location $RepoRoot
+try {
+    if ($Clean) {
+        Write-Host "Cleaning build/ and dist/ ..." -ForegroundColor Yellow
+        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue (Join-Path $RepoRoot "build")
+        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue (Join-Path $RepoRoot "dist")
+    }
+
+    # The spec reads this to locate the GTK runtime tree.
+    $env:AURYN_MINGW_PREFIX = $MingwPrefix
+
+    Write-Host "Running PyInstaller ..." -ForegroundColor Cyan
+    & pyinstaller --noconfirm --clean $SpecFile
+    if ($LASTEXITCODE -ne 0) {
+        throw "PyInstaller failed with exit code $LASTEXITCODE."
+    }
+
+    $OutDir = Join-Path $RepoRoot "dist\Auryn"
+    if (-not (Test-Path (Join-Path $OutDir "Auryn.exe"))) {
+        throw "Build finished but Auryn.exe was not produced in $OutDir."
+    }
+
+    Write-Host ""
+    Write-Host "Build succeeded." -ForegroundColor Green
+    Write-Host "  output  : $OutDir"
+    Write-Host "  launch  : $OutDir\Auryn.exe"
+    Write-Host ""
+    Write-Host "Reminder: this is an experimental, unsigned, manual build."
+    Write-Host "Smoke-test it on a clean Windows VM before sharing."
+}
+finally {
+    Pop-Location
+}

--- a/packaging/windows/runtime_hook_gtk.py
+++ b/packaging/windows/runtime_hook_gtk.py
@@ -1,0 +1,63 @@
+"""
+PyInstaller runtime hook: point GTK3 at the bundled runtime.
+
+Runs before Auryn's own code. GTK / GLib / GdkPixbuf look these up by
+environment variable at startup, so they have to be set early — patching
+them later is too late.
+"""
+import os
+import sys
+
+
+def _bundle_root() -> str:
+    # In --onedir builds, sys._MEIPASS is the directory containing the
+    # collected data tree. Fall back to the executable's folder for older
+    # PyInstaller versions that did not set _MEIPASS for onedir.
+    meipass = getattr(sys, "_MEIPASS", None)
+    if meipass:
+        return meipass
+    return os.path.dirname(os.path.abspath(sys.executable))
+
+
+def _set_if_exists(var: str, path: str) -> None:
+    if os.path.exists(path):
+        os.environ[var] = path
+
+
+def _prepend_path(var: str, path: str) -> None:
+    if not os.path.exists(path):
+        return
+    existing = os.environ.get(var, "")
+    if existing:
+        os.environ[var] = path + os.pathsep + existing
+    else:
+        os.environ[var] = path
+
+
+root = _bundle_root()
+
+# GObject introspection typelibs.
+_set_if_exists("GI_TYPELIB_PATH", os.path.join(root, "lib", "girepository-1.0"))
+
+# gdk-pixbuf loader cache. The cache file ships next to the loader DLLs.
+_set_if_exists(
+    "GDK_PIXBUF_MODULE_FILE",
+    os.path.join(root, "lib", "gdk-pixbuf-2.0", "2.10.0", "loaders.cache"),
+)
+_set_if_exists(
+    "GDK_PIXBUF_MODULEDIR",
+    os.path.join(root, "lib", "gdk-pixbuf-2.0", "2.10.0", "loaders"),
+)
+
+# Where GTK looks for icon themes and GSettings schemas.
+_prepend_path("XDG_DATA_DIRS", os.path.join(root, "share"))
+
+# Fontconfig.
+_set_if_exists("FONTCONFIG_PATH", os.path.join(root, "etc", "fonts"))
+
+# Make the bundled MINGW64 DLLs win the search order on Windows.
+if sys.platform == "win32" and hasattr(os, "add_dll_directory"):
+    try:
+        os.add_dll_directory(root)
+    except (OSError, FileNotFoundError):
+        pass


### PR DESCRIPTION
## Summary

This PR introduces the first Windows packaging setup for Auryn, enabling developers to build a portable `--onedir` bundle locally using PyInstaller on MSYS2 MINGW64.

## Key Changes

- **`Auryn.spec`**: PyInstaller spec file that bundles Auryn with the GTK3 runtime, typelibs, icon themes, and locale data from MSYS2 MINGW64. Explicitly includes GTK runtime components that PyInstaller's automatic analysis cannot discover.

- **`runtime_hook_gtk.py`**: Runtime hook that executes before Auryn's code to configure environment variables (`GI_TYPELIB_PATH`, `GDK_PIXBUF_MODULE_FILE`, `XDG_DATA_DIRS`, `FONTCONFIG_PATH`) pointing GTK3 and related libraries at the bundled runtime tree.

- **`build.ps1`**: PowerShell helper script for invoking PyInstaller with the spec. Validates MSYS2 MINGW64 presence, handles optional `--clean` builds, and provides user-friendly output.

- **`README.md`**: Comprehensive documentation covering build host requirements (MSYS2 MINGW64 packages), build instructions, what the spec ships, smoke-testing guidance, and scope limitations.

## Notable Implementation Details

- The spec resolves the GTK runtime location via the `AURYN_MINGW_PREFIX` environment variable (defaults to `C:/msys64/mingw64`), allowing flexibility for non-standard MSYS2 installations.

- GTK data trees are validated at spec evaluation time; missing paths fail the build loudly rather than producing a broken bundle.

- The bundle is `--onedir` (portable folder), not `--onefile`, to keep the GTK runtime tree accessible and maintainable.

- Streamrip (`rip.exe`) remains an external dependency discovered via PATH at runtime; it is intentionally not bundled.

- An optional `.ico` file from `assets/Auryn.ico` is used as the executable icon if present; the build succeeds without it.

- Status is explicitly marked as experimental: no installer, no CI, no code signing, and no auto-update are included in this PR.

https://claude.ai/code/session_01B4jWCPKE7BkNZwQyweUZQX