### PR TITLE
Defer GTK import and add version flag support

### DIFF
--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -21,6 +21,9 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from core.errors import parse_streamrip_error
 from core.status import build_status_markup
 
+APP_NAME = "Auryn"
+APP_VERSION = "0.1.0"
+
 SYSTEM_NAME = platform.system()
 IS_WINDOWS = SYSTEM_NAME == "Windows"
 IS_MACOS = SYSTEM_NAME == "Darwin"
@@ -1169,6 +1172,10 @@ if __name__ == "__main__":
     if IS_MACOS:
         print("Auryn is not supported on macOS yet. Please use Linux or Windows.")
         raise SystemExit(1)
+
+    if "--version" in sys.argv:
+        print(f"{APP_NAME} {APP_VERSION}")
+        raise SystemExit(0)
 
     if "--doctor" in sys.argv:
         raise SystemExit(0 if run_doctor() else 1)

--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -29,7 +29,6 @@ IS_WINDOWS = SYSTEM_NAME == "Windows"
 IS_MACOS = SYSTEM_NAME == "Darwin"
 IS_UNSUPPORTED_OS = IS_WINDOWS or IS_MACOS
 
-gi = None
 pty = None
 fcntl = None
 
@@ -37,7 +36,10 @@ if not IS_WINDOWS:
     import pty
     import fcntl
 
-if not IS_MACOS:
+
+def _import_gtk():
+    """Import GTK into module globals; deferred so CLI flags work without GTK."""
+    global Gtk, GLib, Gdk, GdkPixbuf, Pango
     import gi
     gi.require_version('Gtk', '3.0')
     gi.require_version('Gdk', '3.0')
@@ -1180,5 +1182,6 @@ if __name__ == "__main__":
     if "--doctor" in sys.argv:
         raise SystemExit(0 if run_doctor() else 1)
 
+    _import_gtk()
     app = AurynApp()
     Gtk.main()


### PR DESCRIPTION
## Summary
This PR improves application startup by deferring GTK initialization and adds support for a `--version` command-line flag. These changes allow CLI operations to work without requiring GTK to be available, and provide better separation of concerns between CLI and GUI functionality.

## Key Changes
- **Deferred GTK import**: Moved GTK and related library imports into a new `_import_gtk()` function that is called only when the GUI is needed, rather than at module load time. This allows CLI operations (like `--doctor`) to run without GTK dependencies.
- **Version flag support**: Added `--version` command-line flag that prints the application name and version, then exits cleanly.
- **App metadata**: Introduced `APP_NAME` and `APP_VERSION` constants at the module level for centralized version management.
- **Removed unused global**: Removed the unused `gi = None` global variable declaration.
- **Improved startup flow**: GTK import now happens explicitly in `main()` after CLI flag checks, making the initialization order clearer.

## Implementation Details
- The `_import_gtk()` function uses `global` declarations to inject GTK-related modules into the module namespace, maintaining compatibility with existing code that expects these to be available globally.
- CLI flags (`--version`, `--doctor`) are now checked before GTK initialization, allowing them to execute independently of GUI availability.
- The version string follows semantic versioning format (0.1.0).

https://claude.ai/code/session_0183da3da3KPB4sZ4vkWVWW1