### PR TITLE
Add troubleshooting guide with --version and --doctor flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,38 @@ Make sure `rip --version` works from the same shell before launching Auryn.
 
 ---
 
+## Troubleshooting
+
+Auryn ships two diagnostic flags to help verify your installation before launching the GUI.
+
+### --version
+
+Prints the application version and exits.
+
+```bash
+python src/Auryn.py --version
+```
+
+### --doctor
+
+Runs a series of preflight checks and reports the result of each one:
+
+| Check | What is verified |
+|---|---|
+| Python | Version meets the minimum requirement |
+| GTK / PyGObject | The `gi` module and GTK 3 bindings are importable |
+| streamrip / rip | The `rip` executable is present on `PATH` |
+| streamrip config | A streamrip configuration file exists |
+| Music folder | The default output directory (`~/Music`) is accessible |
+
+```bash
+python src/Auryn.py --doctor
+```
+
+The command prints a status line for each check. If a check fails, `--doctor` exits immediately with a non-zero exit code; subsequent checks are not run. A clean environment exits with code `0`.
+
+---
+
 ## Project Status
 
 This is an actively developed project.


### PR DESCRIPTION
## Summary
Added comprehensive troubleshooting documentation to the README, including information about two diagnostic command-line flags that help users verify their Auryn installation.

## Changes
- Added new "Troubleshooting" section to README
- Documented `--version` flag that prints the application version
- Documented `--doctor` flag that runs preflight checks including:
  - Python version verification
  - GTK/PyGObject module availability
  - streamrip/rip executable presence on PATH
  - streamrip configuration file existence
  - Music folder accessibility
- Included usage examples and exit code behavior documentation

## Details
The troubleshooting guide provides users with clear diagnostic tools to identify installation issues before launching the GUI. The `--doctor` command performs a series of checks and exits with a non-zero code if any check fails, making it suitable for automated verification scripts as well.

https://claude.ai/code/session_01JfYXsKMFDKknb14PAhtWoK