### PR TITLE
Document --verbose flag for --doctor diagnostic mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,16 @@ python src/Auryn.py --doctor
 
 The command prints a status line for each check. If a check fails, `--doctor` exits immediately with a non-zero exit code; subsequent checks are not run. A clean environment exits with code `0`.
 
+#### Verbose mode
+
+Pass `--verbose` (or the short form `-v`) alongside `--doctor` to include extra diagnostic details with each check:
+
+```bash
+python src/Auryn.py --doctor --verbose
+```
+
+In verbose mode the report additionally includes the active Python executable, the host platform, the resolved `rip` path (or the directories searched when it is not found), the streamrip configuration path, and the default download folder. Use this when filing bug reports or diagnosing environment-specific issues.
+
 ---
 
 ## Project Status


### PR DESCRIPTION
This PR adds documentation for the `--verbose` (or `-v`) flag that can be used alongside the `--doctor` command to provide enhanced diagnostic information.

## Summary
Updated the README to document the verbose mode feature for the doctor command, helping users understand what additional diagnostic details are available when troubleshooting environment-specific issues.

## Changes
- Added a new "Verbose mode" section under the doctor command documentation
- Documented the `--verbose` / `-v` flag syntax and usage
- Explained what additional information is included in verbose mode output: active Python executable, host platform, resolved `rip` path, streamrip configuration path, and default download folder
- Noted the use case for verbose mode: filing bug reports and diagnosing environment-specific issues

## Notes
This is a documentation-only change that describes existing functionality, making it more discoverable for users who need detailed diagnostic information.

https://claude.ai/code/session_014K1HMSs4iiXAo8987ycxwP