### PR TITLE
Add diagnostics dialog with system health check

### DIFF
--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -16,6 +16,8 @@ import json
 import tempfile
 import platform
 import sys
+import io
+import contextlib
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from core.errors import parse_streamrip_error
@@ -279,6 +281,7 @@ class AurynApp:
         self.btn_about     = self.builder.get_object("btn_about")
         self.btn_setup       = self.builder.get_object("btn_setup")
         self.btn_credentials = self.builder.get_object("btn_credentials")
+        self.btn_diagnostics = self.builder.get_object("btn_diagnostics")
         self.btn_choose    = self.builder.get_object("btn_choose_folder")
         self.btn_open      = self.builder.get_object("btn_open_folder")
         self.btn_log       = self.builder.get_object("btn_open_log")
@@ -331,6 +334,7 @@ class AurynApp:
         self.btn_about.set_can_focus(True)
         self.btn_setup.set_can_focus(True)
         self.btn_credentials.set_can_focus(True)
+        self.btn_diagnostics.set_can_focus(True)
         self.cb_clear_cache.set_can_focus(True)
         for cb in self._quality_checks:
             cb.set_can_focus(True)
@@ -354,6 +358,7 @@ class AurynApp:
         self.btn_about.connect("clicked", self._show_about)
         self.btn_setup.connect("clicked", self._show_setup_wizard)
         self.btn_credentials.connect("clicked", self._show_credentials_dialog)
+        self.btn_diagnostics.connect("clicked", self._show_diagnostics)
         self.btn_choose.connect("clicked", self._choose_folder)
         self.btn_open.connect("clicked", self._open_folder)
         self.btn_log.connect("clicked", self._open_log_folder)
@@ -1136,6 +1141,45 @@ class AurynApp:
             os.makedirs(os.path.dirname(acc_path), exist_ok=True)
             with open(acc_path, "w", encoding="utf-8") as f:
                 json.dump(acc_data, f, indent=2)
+        dlg.destroy()
+
+    def _show_diagnostics(self, *_):
+        buf_io = io.StringIO()
+        with contextlib.redirect_stdout(buf_io), contextlib.redirect_stderr(buf_io):
+            try:
+                ok = run_doctor(verbose=True)
+            except Exception as exc:
+                ok = False
+                print(f"FAIL  Diagnostics raised an exception: {exc}")
+        output = buf_io.getvalue() or "(no output)"
+
+        dlg = Gtk.Dialog(
+            title="Auryn Diagnostics",
+            transient_for=self.window,
+            modal=True,
+        )
+        dlg.add_button("Close", Gtk.ResponseType.CLOSE)
+        dlg.set_default_size(720, 480)
+
+        text_view = Gtk.TextView()
+        text_view.set_editable(False)
+        text_view.set_cursor_visible(False)
+        text_view.set_monospace(True)
+        text_view.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
+        text_view.get_buffer().set_text(output)
+
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        scrolled.set_hexpand(True)
+        scrolled.set_vexpand(True)
+        scrolled.add(text_view)
+
+        content = dlg.get_content_area()
+        content.set_border_width(8)
+        content.pack_start(scrolled, True, True, 0)
+        content.show_all()
+
+        dlg.run()
         dlg.destroy()
 
     def _show_about(self, *_):

--- a/src/Auryn.ui
+++ b/src/Auryn.ui
@@ -140,6 +140,22 @@
                 <property name="position">8</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkButton" id="btn_diagnostics">
+                <property name="label">Diagnostics</property>
+                <property name="can-focus">False</property>
+                <property name="receives-default">False</property>
+                <style>
+                  <class name="neutral-btn"/>
+                </style>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="pack-type">end</property>
+                <property name="position">9</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>


### PR DESCRIPTION
## Summary
This PR adds a new "Diagnostics" button to the Auryn UI that displays system health information in a dedicated dialog window. The diagnostics output is captured from the `run_doctor()` function and presented in a scrollable, read-only text view.

## Key Changes
- Added `io` and `contextlib` imports to support output redirection
- Created new `_show_diagnostics()` method that:
  - Captures stdout/stderr from `run_doctor(verbose=True)` using context managers
  - Handles exceptions gracefully with fallback messaging
  - Displays output in a modal dialog with a scrollable text view
  - Uses monospace font for better readability of diagnostic output
- Added `btn_diagnostics` button widget to the UI:
  - Positioned at the end of the button bar (position 9)
  - Styled with the "neutral-btn" CSS class
  - Connected to the new `_show_diagnostics()` handler
- Configured the button with proper focus and interaction settings

## Implementation Details
- The diagnostics dialog is 720x480 pixels with a modal presentation
- Output is displayed in a non-editable, monospace text view with word-character wrapping
- If `run_doctor()` produces no output or raises an exception, a fallback message is shown
- The dialog follows the existing pattern used for other modal dialogs in the application (credentials, about, etc.)

https://claude.ai/code/session_017F8ZNGzaLfUDxZAd8fMEGa