### PR TITLE
Add copy button to diagnostics dialog

### DIFF
--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -1158,8 +1158,16 @@ class AurynApp:
             transient_for=self.window,
             modal=True,
         )
+        copy_btn = dlg.add_button("Copy", 1)
         dlg.add_button("Close", Gtk.ResponseType.CLOSE)
         dlg.set_default_size(720, 480)
+
+        def _on_copy(_btn):
+            clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
+            clipboard.set_text(output, -1)
+            clipboard.store()
+
+        copy_btn.connect("clicked", _on_copy)
 
         text_view = Gtk.TextView()
         text_view.set_editable(False)


### PR DESCRIPTION
This PR adds a "Copy" button to the diagnostics dialog, allowing users to easily copy the diagnostic output to their clipboard.

**Key changes:**
- Added a "Copy" button to the diagnostics dialog that appears alongside the existing "Close" button
- Implemented click handler that copies the diagnostic output text to the system clipboard using GTK's clipboard API
- The clipboard content is stored to ensure persistence after the dialog is closed

**Implementation details:**
- The copy button is created with response ID 1 and connected to a click handler
- The handler retrieves the clipboard using `Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)` and sets the diagnostic output text
- `clipboard.store()` is called to persist the clipboard content beyond the application's lifetime

https://claude.ai/code/session_01318kWGivVaCUUHCyJ8NNR8