### PR TITLE
Add save functionality to diagnostics dialog

### DIFF
--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -1159,6 +1159,7 @@ class AurynApp:
             modal=True,
         )
         copy_btn = dlg.add_button("Copy", 1)
+        save_btn = dlg.add_button("Save", 2)
         dlg.add_button("Close", Gtk.ResponseType.CLOSE)
         dlg.set_default_size(720, 480)
 
@@ -1167,7 +1168,41 @@ class AurynApp:
             clipboard.set_text(output, -1)
             clipboard.store()
 
+        def _on_save(_btn):
+            chooser = Gtk.FileChooserDialog(
+                title="Save Diagnostics",
+                transient_for=dlg,
+                action=Gtk.FileChooserAction.SAVE,
+            )
+            chooser.add_buttons(
+                "Cancel", Gtk.ResponseType.CANCEL,
+                "Save", Gtk.ResponseType.ACCEPT,
+            )
+            chooser.set_current_name("auryn_diagnostics.txt")
+            chooser.set_do_overwrite_confirmation(True)
+            try:
+                if chooser.run() == Gtk.ResponseType.ACCEPT:
+                    path = chooser.get_filename()
+                    if path:
+                        try:
+                            with open(path, "w", encoding="utf-8") as f:
+                                f.write(output)
+                        except OSError as exc:
+                            err = Gtk.MessageDialog(
+                                transient_for=dlg,
+                                modal=True,
+                                message_type=Gtk.MessageType.ERROR,
+                                buttons=Gtk.ButtonsType.OK,
+                                text="Could not save diagnostics",
+                            )
+                            err.format_secondary_text(str(exc))
+                            err.run()
+                            err.destroy()
+            finally:
+                chooser.destroy()
+
         copy_btn.connect("clicked", _on_copy)
+        save_btn.connect("clicked", _on_save)
 
         text_view = Gtk.TextView()
         text_view.set_editable(False)


### PR DESCRIPTION
## Summary
Added the ability to save diagnostic output to a file from the diagnostics dialog, complementing the existing copy-to-clipboard functionality.

## Key Changes
- Added a "Save" button to the diagnostics dialog
- Implemented `_on_save()` handler that:
  - Opens a file chooser dialog with "Save" action
  - Defaults to filename "auryn_diagnostics.txt"
  - Enables overwrite confirmation
  - Writes diagnostic output to the selected file with UTF-8 encoding
  - Displays an error dialog if the save operation fails (e.g., permission denied, invalid path)
  - Properly cleans up the file chooser dialog

## Implementation Details
- The save handler follows the same pattern as the existing copy functionality
- Error handling includes a secondary error message dialog showing the underlying OS exception
- File operations use proper resource management with try/finally to ensure the file chooser is destroyed
- The implementation integrates seamlessly with the existing diagnostics dialog UI

https://claude.ai/code/session_012QLqt7B4aqCJjWwzQMrqC4