### PR TITLE
Add first launch detection for Auryn configuration

### DIFF
--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -171,6 +171,15 @@ def resolve_auryn_data_dir():
     return os.path.expanduser("~/.config/Auryn")
 
 
+def auryn_config_path():
+    return os.path.join(resolve_auryn_data_dir(), "config.json")
+
+
+def is_first_launch():
+    """Return True when no Auryn config file exists yet on disk."""
+    return not os.path.exists(auryn_config_path())
+
+
 def resolve_log_dir():
     if IS_WINDOWS:
         base = os.environ.get("LOCALAPPDATA", os.path.expanduser("~"))
@@ -369,6 +378,7 @@ class AurynApp:
         # ── Afficher ──
         self.window.show_all()
         self.btn_stop.hide()
+        self._is_first_launch = is_first_launch()
         GLib.idle_add(self._first_run_health_check)
 
     # ── Qualité ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
This PR adds functionality to detect whether Auryn is being launched for the first time by checking for the existence of a configuration file.

## Key Changes
- Added `auryn_config_path()` helper function that returns the path to the Auryn config file (`~/.config/Auryn/config.json`)
- Added `is_first_launch()` function that returns `True` when no Auryn config file exists on disk yet
- Store the first launch state in the `AurynApp` instance as `_is_first_launch` during initialization

## Implementation Details
The first launch detection is performed early in the `AurynApp.__init__()` method, before the health check runs. This allows the application to potentially handle first-time setup differently if needed in subsequent logic.

https://claude.ai/code/session_01WoxbjWvsxUc7GzqecGQu2s