### PR TITLE
Add Flatpak packaging for Auryn

### DIFF
--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -1,0 +1,71 @@
+# Flatpak packaging (MVP)
+
+Minimal Flatpak manifest for Auryn. **Status:** starting point — `streamrip`
+is not yet bundled.
+
+## Files
+
+- `io.github.thezupzup.Auryn.yml` — the Flatpak manifest
+- `auryn.sh` — launcher installed at `/app/bin/auryn`
+
+## Runtime
+
+We use `org.gnome.Platform` 45 (which is built on top of
+`org.freedesktop.Platform`) because it ships GTK3, PyGObject and Python 3 out
+of the box, so the manifest stays short. Switching to a pure
+`org.freedesktop.Platform` base would require building GTK and PyGObject as
+extra modules.
+
+## Manifest sections explained
+
+- `app-id` — reverse-DNS application ID. Must match the desktop file and
+  icon names installed under `/app/share`.
+- `runtime` / `runtime-version` / `sdk` — the platform the app runs against
+  and the SDK used at build time.
+- `command` — what `flatpak run` invokes; here it's the `auryn` script.
+- `finish-args` — sandbox permissions: X11/Wayland for display, PulseAudio
+  for sound, network for streamrip downloads, and access to
+  `~/Music` / `~/Downloads` for output.
+- `modules` — build steps. The single `auryn` module copies the sources to
+  `/app/share/auryn`, drops a launcher in `/app/bin`, and installs the
+  desktop file and icons under their app-id-prefixed names.
+- The commented `python3-streamrip` block is a TODO: generate a real entry
+  with `flatpak-pip-generator streamrip` and paste it above the `auryn`
+  module.
+
+## Build & test locally
+
+From the repo root:
+
+```sh
+# 1. Install build tooling and the runtime/SDK once
+flatpak install --user flathub \
+    org.gnome.Platform//45 org.gnome.Sdk//45
+
+# 2. Build into a local repo
+flatpak-builder --user --force-clean \
+    build-dir packaging/flatpak/io.github.thezupzup.Auryn.yml
+
+# 3. Install the built app for the current user
+flatpak-builder --user --install --force-clean \
+    build-dir packaging/flatpak/io.github.thezupzup.Auryn.yml
+
+# 4. Run it
+flatpak run io.github.thezupzup.Auryn
+```
+
+For quick iteration without installing:
+
+```sh
+flatpak-builder --run build-dir \
+    packaging/flatpak/io.github.thezupzup.Auryn.yml auryn
+```
+
+## Next steps
+
+1. Run `flatpak-pip-generator streamrip` to produce
+   `python3-streamrip.json`, then reference it as a module in the manifest.
+2. Add an AppStream metainfo file
+   (`io.github.thezupzup.Auryn.metainfo.xml`).
+3. Rename `desktop/Auryn.desktop` to `io.github.thezupzup.Auryn.desktop`
+   upstream so the manifest doesn't have to rename on install.

--- a/packaging/flatpak/auryn.sh
+++ b/packaging/flatpak/auryn.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec python3 /app/share/auryn/Auryn.py "$@"

--- a/packaging/flatpak/io.github.thezupzup.Auryn.yml
+++ b/packaging/flatpak/io.github.thezupzup.Auryn.yml
@@ -1,0 +1,53 @@
+app-id: io.github.thezupzup.Auryn
+runtime: org.gnome.Platform
+runtime-version: '45'
+sdk: org.gnome.Sdk
+command: auryn
+
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --device=dri
+  - --filesystem=xdg-music
+  - --filesystem=xdg-download
+
+modules:
+  # TODO: package streamrip and its Python dependencies here as a proper
+  # python3-modules entry generated via flatpak-pip-generator. For now this
+  # MVP manifest only builds the Auryn GUI; streamrip must be installed by
+  # the user inside the sandbox or bundled later.
+  #
+  # Example (to be filled in):
+  # - name: python3-streamrip
+  #   buildsystem: simple
+  #   build-commands:
+  #     - pip3 install --prefix=/app --no-deps streamrip
+  #   sources: [...]
+
+  - name: auryn
+    buildsystem: simple
+    build-commands:
+      # Install the Python sources into /app/share/auryn
+      - mkdir -p /app/share/auryn
+      - cp -r src/* /app/share/auryn/
+
+      # Launcher script on PATH
+      - install -Dm755 packaging/flatpak/auryn.sh /app/bin/auryn
+
+      # Desktop entry (renamed to match app-id)
+      - install -Dm644 desktop/Auryn.desktop
+          /app/share/applications/io.github.thezupzup.Auryn.desktop
+
+      # Icons
+      - install -Dm644 assets/Auryn.svg
+          /app/share/icons/hicolor/scalable/apps/io.github.thezupzup.Auryn.svg
+      - install -Dm644 assets/Auryn_256.png
+          /app/share/icons/hicolor/256x256/apps/io.github.thezupzup.Auryn.png
+      - install -Dm644 assets/Auryn_48.png
+          /app/share/icons/hicolor/48x48/apps/io.github.thezupzup.Auryn.png
+    sources:
+      - type: dir
+        path: ../..


### PR DESCRIPTION
## Summary
This PR adds Flatpak packaging support for Auryn, enabling distribution and installation via Flathub. The implementation provides a minimal viable product (MVP) that bundles the Auryn GUI while noting that `streamrip` integration is a future enhancement.

## Changes
- **Flatpak manifest** (`io.github.thezupzup.Auryn.yml`): Defines the application configuration using GNOME Platform 45 runtime, which provides GTK3, PyGObject, and Python 3 out of the box. Includes sandbox permissions for display (X11/Wayland), audio (PulseAudio), networking, and filesystem access to Music and Downloads directories.
- **Launcher script** (`auryn.sh`): Simple shell wrapper that invokes the Python application from its installed location at `/app/share/auryn/Auryn.py`.
- **Documentation** (`README.md`): Comprehensive guide explaining the manifest structure, runtime choice rationale, build/test instructions, and next steps for completing the packaging (streamrip bundling, AppStream metadata, desktop file naming).

## Notable Details
- Uses `org.gnome.Platform` 45 as the base runtime to minimize manifest complexity and avoid rebuilding GTK and PyGObject
- Installs desktop entry and icons with app-id-prefixed names to comply with Flatpak conventions
- Includes placeholder for future `python3-streamrip` module generation via `flatpak-pip-generator`
- Provides clear local build and testing instructions for developers

https://claude.ai/code/session_01YEeJGPF823bMVebV7Y9drc