### PR TITLE
ui: complete Qrip→Auryn rebrand and polish GTK strings

### DIFF
--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -24,7 +24,7 @@ from core.errors import parse_streamrip_error
 from core.status import build_status_markup
 
 APP_NAME = "Auryn"
-APP_VERSION = "0.1.0"
+APP_VERSION = "0.1.1"
 
 SYSTEM_NAME = platform.system()
 IS_WINDOWS = SYSTEM_NAME == "Windows"
@@ -410,8 +410,12 @@ class AurynApp:
                         Gtk.STOCK_OPEN,   Gtk.ResponseType.OK)
         if dlg.run() == Gtk.ResponseType.OK:
             self._dest_folder = dlg.get_filename()
+            safe_path = (self._dest_folder
+                         .replace("&", "&amp;")
+                         .replace("<", "&lt;")
+                         .replace(">", "&gt;"))
             self.folder_lbl.set_markup(
-                f'<span foreground="#FF6B35" size="small">📁  {self._dest_folder}</span>')
+                f'<span foreground="#FF6B35" size="small">📁  {safe_path}</span>')
         dlg.destroy()
 
     def _open_folder(self, *_):
@@ -447,8 +451,8 @@ class AurynApp:
         self._track_done       = 0
         self._total_tracks     = 0
         self._last_known_error = None
-        self._set_status("⏳   Fetching album info...", "info")
-        self._set_lyrics('<span foreground="#444444"><i>Lyrics will appear here during download...</i></span>')
+        self._set_status("⏳  Fetching album info...", "info")
+        self._set_lyrics('<span foreground="#555555"><i>Lyrics appear here once a track is identified.</i></span>')
         quality = self._get_quality()
         threading.Thread(target=self._thread_main, args=(url, quality), daemon=True).start()
 
@@ -535,14 +539,14 @@ class AurynApp:
         if pb:
             GLib.idle_add(self.cover_img.set_from_pixbuf, pb)
             GLib.idle_add(self.cover_lbl.set_markup,
-                          '<span foreground="#555555" size="small">Cover Art</span>')
+                          '<span foreground="#888888" size="small" letter_spacing="200">COVER</span>')
 
     def _load_cover(self, cover_url):
         pb = download_cover(cover_url, size=185)
         if pb:
             GLib.idle_add(self.cover_img.set_from_pixbuf, pb)
             GLib.idle_add(self.cover_lbl.set_markup,
-                          '<span foreground="#555555" size="small">Cover Art</span>')
+                          '<span foreground="#888888" size="small" letter_spacing="200">COVER</span>')
 
     # ── Lancement streamrip ───────────────────────────────────────────────────
 
@@ -631,13 +635,13 @@ class AurynApp:
         body = (
             "The setup wizard will help you configure:\n"
             "  • Download folder\n"
-            "  • streamrip credentials & config\n\n"
+            "  • streamrip credentials and config\n\n"
         )
         if rip_found:
             body += "streamrip (rip) was detected on your system."
         else:
             body += (
-                "streamrip (rip) was NOT found.\n"
+                "streamrip (rip) was not found.\n"
                 "Install it with:  pip install streamrip"
             )
 
@@ -646,7 +650,7 @@ class AurynApp:
             flags=0,
             message_type=Gtk.MessageType.INFO,
             buttons=Gtk.ButtonsType.NONE,
-            text="Welcome to Auryn! Let's get you set up.",
+            text="Welcome to Auryn — let's get you set up.",
         )
         dlg.format_secondary_text(body)
         dlg.add_button("Get Started", Gtk.ResponseType.OK)

--- a/src/Auryn.ui
+++ b/src/Auryn.ui
@@ -20,7 +20,7 @@
             <child>
               <object class="GtkLabel" id="logo_label">
                 <property name="can-focus">False</property>
-                <property name="label">&lt;span foreground="#FF6B35" size="x-large" weight="bold"&gt; Q&lt;/span&gt;&lt;span foreground="#ffffff" size="x-large" weight="bold"&gt;rip&lt;/span&gt;</property>
+                <property name="label">&lt;span foreground="#FF6B35" size="x-large" weight="bold" letter_spacing="600"&gt; Au&lt;/span&gt;&lt;span foreground="#ffffff" size="x-large" weight="bold" letter_spacing="600"&gt;ryn&lt;/span&gt;</property>
                 <property name="use-markup">True</property>
               </object>
               <packing>
@@ -110,7 +110,7 @@
             </child>
             <child>
               <object class="GtkButton" id="btn_about">
-                <property name="label"> i </property>
+                <property name="label">About</property>
                 <property name="can-focus">False</property>
                 <property name="receives-default">False</property>
                 <style>
@@ -179,7 +179,7 @@
                   <object class="GtkLabel" id="lbl_url">
                     <property name="can-focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label">&lt;span foreground="#666666" size="small"&gt;Source&lt;/span&gt;</property>
+                    <property name="label">&lt;span foreground="#888888" size="small" letter_spacing="200"&gt;SOURCE URL&lt;/span&gt;</property>
                     <property name="use-markup">True</property>
                   </object>
                   <packing>
@@ -192,7 +192,7 @@
                   <object class="GtkEntry" id="url_entry">
                     <property name="name">url_entry</property>
                     <property name="can-focus">False</property>
-                    <property name="placeholder-text">Paste source URL...</property>
+                    <property name="placeholder-text">Paste a Qobuz, Tidal, Deezer, or SoundCloud URL</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -338,7 +338,7 @@
                   <object class="GtkLabel" id="folder_lbl">
                     <property name="can-focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label">&lt;span foreground="#404040" size="small"&gt;📁  ~/Files&lt;/span&gt;</property>
+                    <property name="label">&lt;span foreground="#666666" size="small"&gt;📁  ~/Music&lt;/span&gt;</property>
                     <property name="use-markup">True</property>
                   </object>
                   <packing>
@@ -367,7 +367,7 @@
                     <property name="spacing">8</property>
                     <child>
                       <object class="GtkButton" id="btn_download">
-                        <property name="label">Start Process</property>
+                        <property name="label">Start Download</property>
                         <property name="name">btn_download</property>
                         <property name="can-focus">False</property>
                         <property name="receives-default">False</property>
@@ -402,7 +402,7 @@
                   <object class="GtkLabel" id="status_lbl">
                     <property name="can-focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label">&lt;span foreground="#555555" size="small"&gt;Ready.&lt;/span&gt;</property>
+                    <property name="label">&lt;span foreground="#777777" size="small"&gt;Ready — paste a URL to begin.&lt;/span&gt;</property>
                     <property name="use-markup">True</property>
                     <property name="ellipsize">end</property>
                   </object>
@@ -468,7 +468,7 @@
                             <property name="margin-end">10</property>
                             <property name="margin-top">10</property>
                             <property name="margin-bottom">10</property>
-                            <property name="label" translatable="yes">&lt;span foreground="#333333" size="small"&gt;—&lt;/span&gt;</property>
+                            <property name="label" translatable="yes">&lt;span foreground="#555555" size="small"&gt;&lt;i&gt;Lyrics appear here once a track is identified.&lt;/i&gt;&lt;/span&gt;</property>
                             <property name="use-markup">True</property>
                             <property name="wrap">True</property>
                             <property name="wrap-mode">word-char</property>
@@ -530,7 +530,7 @@
                 <child>
                   <object class="GtkLabel" id="cover_lbl">
                     <property name="can-focus">False</property>
-                    <property name="label">&lt;span foreground="#333333" size="small"&gt;Cover Art&lt;/span&gt;</property>
+                    <property name="label">&lt;span foreground="#555555" size="small" letter_spacing="200"&gt;COVER&lt;/span&gt;</property>
                     <property name="use-markup">True</property>
                   </object>
                   <packing>
@@ -796,7 +796,7 @@
               <object class="GtkLabel" id="footer_lbl">
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="label">&lt;span foreground="#333333" size="small"&gt;  Auryn v0.1.1 — Ready&lt;/span&gt;</property>
+                <property name="label">&lt;span foreground="#444444" size="small"&gt;  Auryn v0.1.1  ·  streamrip GUI&lt;/span&gt;</property>
                 <property name="use-markup">True</property>
               </object>
               <packing>


### PR DESCRIPTION
## Summary

Finishes the in-app Qrip → Auryn rebrand and polishes the GTK strings/UX. No download or streamrip integration logic was touched. No dependencies, file renames, or layout rewrites.

### User-facing string changes

| Where | Before | After |
|---|---|---|
| `Auryn.ui` header logo wordmark | ` Qrip` (orange "Q" + white "rip") | ` Auryn` (orange "Au" + white "ryn", small letter spacing) |
| `Auryn.ui` header `btn_about` label | ` i ` | `About` |
| `Auryn.ui` `lbl_url` (left panel section) | `Source` | `SOURCE URL` (small caps, letter-spaced) |
| `Auryn.ui` `url_entry` placeholder | `Paste source URL...` | `Paste a Qobuz, Tidal, Deezer, or SoundCloud URL` |
| `Auryn.ui` `folder_lbl` default | `📁  ~/Files` | `📁  ~/Music` (matches actual default) |
| `Auryn.ui` `btn_download` label | `Start Process` | `Start Download` |
| `Auryn.ui` `status_lbl` default | `Ready.` | `Ready — paste a URL to begin.` |
| `Auryn.ui` `cover_lbl` label | `Cover Art` | `COVER` (small caps, letter-spaced) |
| `Auryn.ui` `lyrics_label` empty state | `—` | `Lyrics appear here once a track is identified.` |
| `Auryn.ui` `footer_lbl` | `  Auryn v0.1.1 — Ready` | `  Auryn v0.1.1  ·  streamrip GUI` |
| `Auryn.py` runtime "Cover Art" caption (after cover loads) | `Cover Art` | `COVER` |
| `Auryn.py` initial download status | `⏳   Fetching album info...` (3 spaces) | `⏳  Fetching album info...` (consistent 2-space gap) |
| `Auryn.py` initial lyrics placeholder | `Lyrics will appear here during download...` | `Lyrics appear here once a track is identified.` |
| `Auryn.py` welcome dialog title | `Welcome to Auryn! Let's get you set up.` | `Welcome to Auryn — let's get you set up.` |
| `Auryn.py` welcome body | `streamrip credentials & config` / `streamrip (rip) was NOT found.` | `streamrip credentials and config` / `streamrip (rip) was not found.` |

### Other small fixes

- `APP_VERSION` constant in `Auryn.py` bumped from `0.1.0` → `0.1.1` to match the version already shown in the window title, footer and About dialog (used by `--version`).
- The chosen folder path is now Pango-escaped before being inserted into the `folder_lbl` markup, so paths containing `&`, `<`, or `>` no longer break the label.

### Out of scope (intentionally untouched)

- streamrip / `rip` invocation, config edits, account file paths
- Quality detection regexes and download parsing
- File names (`Auryn.py`, `Auryn.ui`, `core/*`, packaging spec)
- README, desktop entry, assets, packaging configs (already Auryn-branded)
- Compatibility paths (`~/.config/Auryn`, `~/.local/state/Auryn`, `XDG_CONFIG_HOME/streamrip`, `%APPDATA%/Auryn`)

## Test plan

- [x] `python3 -m py_compile src/Auryn.py` passes
- [x] `Auryn.ui` re-validates as well-formed XML
- [x] Repo grep shows zero remaining `Qrip` / `qrip` references
- [ ] Manual smoke test on a Linux GTK3 desktop: launch the app, verify the new wordmark renders, the placeholder/help text reads as expected, and Start Download still kicks off a download flow end-to-end

https://claude.ai/code/session_01AtWgrxA6pdKpVJoV3byU85

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtWgrxA6pdKpVJoV3byU85)_