### PR TITLE
ui: move Open Downloads Folder button next to folder controls

### DIFF
--- a/src/Auryn.ui
+++ b/src/Auryn.ui
@@ -109,23 +109,6 @@
               </packing>
             </child>
             <child>
-              <object class="GtkButton" id="btn_open_downloads_folder">
-                <property name="label">Open Downloads Folder</property>
-                <property name="tooltip-text">Open the configured download folder in your file manager</property>
-                <property name="can-focus">False</property>
-                <property name="receives-default">False</property>
-                <style>
-                  <class name="neutral-btn"/>
-                </style>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="pack-type">end</property>
-                <property name="position">10</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkButton" id="btn_about">
                 <property name="label">About</property>
                 <property name="can-focus">False</property>
@@ -342,6 +325,22 @@
                         <property name="expand">False</property>
                         <property name="fill">False</property>
                         <property name="position">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="btn_open_downloads_folder">
+                        <property name="label">Open Downloads Folder</property>
+                        <property name="tooltip-text">Open the configured download folder in your file manager</property>
+                        <property name="can-focus">False</property>
+                        <property name="receives-default">False</property>
+                        <style>
+                          <class name="neutral-btn"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">4</property>
                       </packing>
                     </child>
                   </object>


### PR DESCRIPTION
## Summary
- Relocates the `Open Downloads Folder` button from the header bar into the folder/download controls row, so it sits next to `Choose Destination Folder`, `Open Destination Folder`, and `Open Log Folder` where users already manage paths.
- Behavior is unchanged: the existing handler opens the configured download folder via the cross-platform `open_in_file_manager` helper (`xdg-open` on Linux, `open` on macOS, `os.startfile` on Windows) and shows a GTK error dialog when the folder is missing or fails to launch.
- Pure UI move: no Python changes, no new dependencies, download logic untouched.

## Test plan
- [x] `python3 -m py_compile src/Auryn.py` passes
- [ ] Launch GTK UI; the `Open Downloads Folder` button appears in the folder controls row (no longer in the header)
- [ ] With a valid configured folder, clicking opens it in the system file manager
- [ ] With a non-existent folder, an error dialog is shown (folder is NOT auto-created)
- [ ] Existing `Choose Destination Folder`, `Open Destination Folder`, and `Open Log Folder` buttons still work

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvEBDUL2CjQrydqMwEa7ja)_