### PR TITLE
Add --doctor --report flag to save diagnostics to file

### DIFF
--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -1360,6 +1360,19 @@ if __name__ == "__main__":
 
     if "--doctor" in sys.argv:
         verbose = "--verbose" in sys.argv or "-v" in sys.argv
+        if "--report" in sys.argv:
+            buf_io = io.StringIO()
+            with contextlib.redirect_stdout(buf_io), contextlib.redirect_stderr(buf_io):
+                try:
+                    ok = run_doctor(verbose=verbose)
+                except Exception as exc:
+                    ok = False
+                    print(f"FAIL  Diagnostics raised an exception: {exc}")
+            report_path = os.path.abspath("auryn_diagnostics.txt")
+            with open(report_path, "w", encoding="utf-8") as f:
+                f.write(buf_io.getvalue() or "(no output)")
+            print(f"Diagnostics saved to {report_path}")
+            raise SystemExit(0 if ok else 1)
         raise SystemExit(0 if run_doctor(verbose=verbose) else 1)
 
     _import_gtk()


### PR DESCRIPTION
## Summary
- Add `--report` flag to `--doctor` that writes captured `run_doctor` output to `auryn_diagnostics.txt` in the current directory and prints a confirmation with the full path.
- Reuses the existing `run_doctor` function (no logic duplication) and respects `--verbose` when combined.
- Existing `--doctor` and `--doctor --verbose` behavior, output, and exit codes are unchanged. No new dependencies (`io` and `contextlib` are already imported).

## Test plan
- [x] `python3 -m py_compile src/Auryn.py` passes.
- [ ] `python src/Auryn.py --doctor` prints to stdout as before, exit code unchanged.
- [ ] `python src/Auryn.py --doctor --verbose` prints verbose output to stdout as before.
- [ ] `python src/Auryn.py --doctor --report` writes `auryn_diagnostics.txt` in CWD and prints the saved path; exit code matches `run_doctor`.
- [ ] `python src/Auryn.py --doctor --report --verbose` saves the verbose output to the same file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfP8gzpXzYoWqost1Kt54D)_