### PR TITLE
ci: build Auryn .deb on push, PR, and version tags

### DIFF
--- a/.github/workflows/deb-package.yml
+++ b/.github/workflows/deb-package.yml
@@ -1,0 +1,51 @@
+name: Debian package
+
+on:
+  push:
+    branches: [ "main" ]
+    tags: [ "v*" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: write
+
+jobs:
+  build-deb:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y dpkg-dev lintian
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          else
+            VERSION="$(grep -E '^APP_VERSION\s*=' src/Auryn.py | head -n1 | cut -d'"' -f2)"
+          fi
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build .deb
+        run: packaging/debian/build-deb.sh "${{ steps.version.outputs.version }}"
+
+      - name: Lint .deb (informational)
+        run: lintian --no-tag-display-limit dist/*.deb || true
+
+      - name: Upload .deb artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: auryn-deb-${{ steps.version.outputs.version }}
+          path: dist/*.deb
+
+      - name: Attach .deb to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.deb

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+dist/

--- a/packaging/debian/build-deb.sh
+++ b/packaging/debian/build-deb.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Build a Debian/Ubuntu .deb package for Auryn using dpkg-deb.
+#
+# Usage:
+#   packaging/debian/build-deb.sh [VERSION]
+#
+# If VERSION is not provided, it is extracted from src/Auryn.py (APP_VERSION).
+# The resulting .deb is written to dist/.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+# --- Resolve version -------------------------------------------------------
+# Priority: explicit arg > APP_VERSION in src/Auryn.py > fallback.
+# To bump the package version, update APP_VERSION in src/Auryn.py.
+VERSION="${1:-}"
+if [ -z "${VERSION}" ]; then
+    VERSION="$(grep -E '^APP_VERSION\s*=' src/Auryn.py | head -n1 | cut -d'"' -f2 || true)"
+fi
+VERSION="${VERSION:-0.0.0}"
+
+PKG_NAME="auryn"
+ARCH="all"
+STAGE="$(mktemp -d)"
+trap 'rm -rf "${STAGE}"' EXIT
+
+PKG_ROOT="${STAGE}/${PKG_NAME}_${VERSION}_${ARCH}"
+
+# --- Layout ----------------------------------------------------------------
+install -d "${PKG_ROOT}/DEBIAN"
+install -d "${PKG_ROOT}/usr/bin"
+install -d "${PKG_ROOT}/usr/share/auryn"
+install -d "${PKG_ROOT}/usr/share/auryn/core"
+install -d "${PKG_ROOT}/usr/share/applications"
+install -d "${PKG_ROOT}/usr/share/icons/hicolor/scalable/apps"
+for size in 16 32 48 256; do
+    install -d "${PKG_ROOT}/usr/share/icons/hicolor/${size}x${size}/apps"
+done
+
+# Python sources
+install -m 0644 src/Auryn.py "${PKG_ROOT}/usr/share/auryn/Auryn.py"
+install -m 0644 src/Auryn.ui "${PKG_ROOT}/usr/share/auryn/Auryn.ui"
+install -m 0644 src/core/__init__.py "${PKG_ROOT}/usr/share/auryn/core/__init__.py"
+install -m 0644 src/core/errors.py "${PKG_ROOT}/usr/share/auryn/core/errors.py"
+install -m 0644 src/core/status.py "${PKG_ROOT}/usr/share/auryn/core/status.py"
+
+# Desktop entry (already present in repo)
+install -m 0644 desktop/Auryn.desktop "${PKG_ROOT}/usr/share/applications/Auryn.desktop"
+
+# Icons
+install -m 0644 assets/Auryn.svg "${PKG_ROOT}/usr/share/icons/hicolor/scalable/apps/Auryn.svg"
+for size in 16 32 48 256; do
+    install -m 0644 "assets/Auryn_${size}.png" \
+        "${PKG_ROOT}/usr/share/icons/hicolor/${size}x${size}/apps/Auryn.png"
+done
+
+# Launcher: /usr/bin/Auryn -> python3 /usr/share/auryn/Auryn.py
+# Named "Auryn" (capital A) to match the existing desktop entry's Exec=Auryn.
+# A lowercase "auryn" symlink is provided as a convenience for shells.
+cat > "${PKG_ROOT}/usr/bin/Auryn" <<'EOF'
+#!/bin/sh
+exec python3 /usr/share/auryn/Auryn.py "$@"
+EOF
+chmod 0755 "${PKG_ROOT}/usr/bin/Auryn"
+ln -s Auryn "${PKG_ROOT}/usr/bin/auryn"
+
+# --- Control file ----------------------------------------------------------
+# streamrip is not packaged in the Debian/Ubuntu archives, so we leave it as a
+# "Recommends" with a note for users to install it via pipx/pip. The package
+# itself only hard-depends on python3 + PyGObject + GTK.
+cat > "${PKG_ROOT}/DEBIAN/control" <<EOF
+Package: ${PKG_NAME}
+Version: ${VERSION}
+Section: sound
+Priority: optional
+Architecture: ${ARCH}
+Depends: python3, python3-gi, gir1.2-gtk-3.0
+Recommends: streamrip
+Maintainer: TheZupZup <noreply@github.com>
+Homepage: https://github.com/thezupzup/auryn
+Description: GTK GUI for streamrip
+ Auryn is a simple GTK 3 graphical front-end for the streamrip
+ command-line music downloader. If the 'streamrip' package is not
+ available on your distribution, install it with:
+ .
+   pipx install streamrip
+EOF
+
+# --- Build -----------------------------------------------------------------
+mkdir -p dist
+OUT="dist/${PKG_NAME}_${VERSION}_${ARCH}.deb"
+dpkg-deb --build --root-owner-group "${PKG_ROOT}" "${OUT}"
+
+echo "Built: ${OUT}"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deb-package.yml` that builds a `.deb` on pushes to `main`, PRs, and `v*` tags, uploads it as a workflow artifact, and attaches it to the GitHub Release on tag builds.
- Adds `packaging/debian/build-deb.sh`, a small `dpkg-deb`-based builder. Layout:
  - `/usr/share/auryn/{Auryn.py,Auryn.ui,core/*}`
  - `/usr/bin/Auryn` (matches existing `desktop/Auryn.desktop` `Exec=Auryn`) plus a lowercase `auryn` symlink
  - `desktop/Auryn.desktop` installed to `/usr/share/applications/`
  - Icons installed to `/usr/share/icons/hicolor/{16,32,48,256,scalable}/apps/`
- `.gitignore`: ignore `dist/`.

## Package metadata
- **Name**: `auryn`
- **Version**: extracted from `APP_VERSION` in `src/Auryn.py` (currently `0.1.1`); on tag builds the `vX.Y.Z` tag wins. Bump `APP_VERSION` to bump the package version for non-tag builds.
- **Description**: `GTK GUI for streamrip`
- **Depends**: `python3, python3-gi, gir1.2-gtk-3.0`
- **Recommends**: `streamrip` (not in Debian/Ubuntu archives — control file notes the `pipx install streamrip` fallback)

Download logic is untouched.

## Test plan
- [x] `packaging/debian/build-deb.sh` produces `dist/auryn_0.1.1_all.deb` locally
- [x] `dpkg-deb --info` / `--contents` show expected metadata and layout
- [ ] CI run on this PR builds the `.deb` and uploads the artifact
- [ ] A future `vX.Y.Z` tag push attaches the `.deb` to the matching Release

https://claude.ai/code/session_01GcPDtxXpENGeCDSGcBYPpn

---
_Generated by [Claude Code](https://claude.ai/code/session_01GcPDtxXpENGeCDSGcBYPpn)_