### PR TITLE
ci: build Auryn .deb and .rpm on push, PR, and version tags

### DIFF
--- a/.github/workflows/linux-packages.yml
+++ b/.github/workflows/linux-packages.yml
@@ -1,0 +1,99 @@
+name: Linux packages
+
+on:
+  push:
+    branches: [ "main" ]
+    tags: [ "v*" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: write
+
+jobs:
+  # On tag builds we want the package version to match the tag.
+  # Otherwise we read APP_VERSION from src/Auryn.py.
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: resolve
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          else
+            VERSION="$(grep -E '^APP_VERSION\s*=' src/Auryn.py | head -n1 | cut -d'"' -f2)"
+          fi
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+
+  build-deb:
+    needs: version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y dpkg-dev lintian
+
+      - name: Build .deb
+        run: packaging/debian/build-deb.sh "${{ needs.version.outputs.version }}"
+
+      - name: Lint .deb (informational)
+        run: lintian --no-tag-display-limit dist/*.deb || true
+
+      - name: Upload .deb artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: auryn-deb-${{ needs.version.outputs.version }}
+          path: dist/*.deb
+
+  build-rpm:
+    needs: version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rpm rpmlint
+
+      - name: Build .rpm
+        run: packaging/rpm/build-rpm.sh "${{ needs.version.outputs.version }}"
+
+      - name: Lint .rpm (informational)
+        run: rpmlint dist/*.rpm || true
+
+      - name: Upload .rpm artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: auryn-rpm-${{ needs.version.outputs.version }}
+          path: dist/*.rpm
+
+  release:
+    needs: [version, build-deb, build-rpm]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download .deb
+        uses: actions/download-artifact@v4
+        with:
+          name: auryn-deb-${{ needs.version.outputs.version }}
+          path: dist
+
+      - name: Download .rpm
+        uses: actions/download-artifact@v4
+        with:
+          name: auryn-rpm-${{ needs.version.outputs.version }}
+          path: dist
+
+      - name: Attach packages to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/*.deb
+            dist/*.rpm

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+dist/

--- a/packaging/debian/build-deb.sh
+++ b/packaging/debian/build-deb.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Build a Debian/Ubuntu .deb package for Auryn using dpkg-deb.
+#
+# Usage:
+#   packaging/debian/build-deb.sh [VERSION]
+#
+# If VERSION is not provided, it is extracted from src/Auryn.py (APP_VERSION).
+# The resulting .deb is written to dist/.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+# --- Resolve version -------------------------------------------------------
+# Priority: explicit arg > APP_VERSION in src/Auryn.py > fallback.
+# To bump the package version, update APP_VERSION in src/Auryn.py.
+VERSION="${1:-}"
+if [ -z "${VERSION}" ]; then
+    VERSION="$(grep -E '^APP_VERSION\s*=' src/Auryn.py | head -n1 | cut -d'"' -f2 || true)"
+fi
+VERSION="${VERSION:-0.0.0}"
+
+PKG_NAME="auryn"
+ARCH="all"
+STAGE="$(mktemp -d)"
+trap 'rm -rf "${STAGE}"' EXIT
+
+PKG_ROOT="${STAGE}/${PKG_NAME}_${VERSION}_${ARCH}"
+
+# --- Layout ----------------------------------------------------------------
+install -d "${PKG_ROOT}/DEBIAN"
+install -d "${PKG_ROOT}/usr/bin"
+install -d "${PKG_ROOT}/usr/share/auryn"
+install -d "${PKG_ROOT}/usr/share/auryn/core"
+install -d "${PKG_ROOT}/usr/share/applications"
+install -d "${PKG_ROOT}/usr/share/icons/hicolor/scalable/apps"
+for size in 16 32 48 256; do
+    install -d "${PKG_ROOT}/usr/share/icons/hicolor/${size}x${size}/apps"
+done
+
+# Python sources
+install -m 0644 src/Auryn.py "${PKG_ROOT}/usr/share/auryn/Auryn.py"
+install -m 0644 src/Auryn.ui "${PKG_ROOT}/usr/share/auryn/Auryn.ui"
+install -m 0644 src/core/__init__.py "${PKG_ROOT}/usr/share/auryn/core/__init__.py"
+install -m 0644 src/core/errors.py "${PKG_ROOT}/usr/share/auryn/core/errors.py"
+install -m 0644 src/core/status.py "${PKG_ROOT}/usr/share/auryn/core/status.py"
+
+# Desktop entry (already present in repo)
+install -m 0644 desktop/Auryn.desktop "${PKG_ROOT}/usr/share/applications/Auryn.desktop"
+
+# Icons
+install -m 0644 assets/Auryn.svg "${PKG_ROOT}/usr/share/icons/hicolor/scalable/apps/Auryn.svg"
+for size in 16 32 48 256; do
+    install -m 0644 "assets/Auryn_${size}.png" \
+        "${PKG_ROOT}/usr/share/icons/hicolor/${size}x${size}/apps/Auryn.png"
+done
+
+# Launcher: /usr/bin/Auryn -> python3 /usr/share/auryn/Auryn.py
+# Named "Auryn" (capital A) to match the existing desktop entry's Exec=Auryn.
+# A lowercase "auryn" symlink is provided as a convenience for shells.
+cat > "${PKG_ROOT}/usr/bin/Auryn" <<'EOF'
+#!/bin/sh
+exec python3 /usr/share/auryn/Auryn.py "$@"
+EOF
+chmod 0755 "${PKG_ROOT}/usr/bin/Auryn"
+ln -s Auryn "${PKG_ROOT}/usr/bin/auryn"
+
+# --- Control file ----------------------------------------------------------
+# streamrip is not reliably packaged in Debian/Ubuntu archives. We keep it as
+# a "Recommends" only and document the pip/pipx fallback; Auryn itself
+# detects a missing 'rip' at runtime and offers to install it.
+cat > "${PKG_ROOT}/DEBIAN/control" <<EOF
+Package: ${PKG_NAME}
+Version: ${VERSION}
+Section: sound
+Priority: optional
+Architecture: ${ARCH}
+Depends: python3, python3-gi, gir1.2-gtk-3.0
+Recommends: streamrip
+Maintainer: TheZupZup <noreply@github.com>
+Homepage: https://github.com/thezupzup/auryn
+Description: GTK GUI for streamrip
+ Auryn is a simple GTK 3 graphical front-end for the streamrip
+ command-line music downloader. If the 'streamrip' package is not
+ available on your distribution, install it with:
+ .
+   pipx install streamrip
+EOF
+
+# --- Build -----------------------------------------------------------------
+mkdir -p dist
+OUT="dist/${PKG_NAME}_${VERSION}_${ARCH}.deb"
+dpkg-deb --build --root-owner-group "${PKG_ROOT}" "${OUT}"
+
+echo "Built: ${OUT}"

--- a/packaging/rpm/auryn.spec
+++ b/packaging/rpm/auryn.spec
@@ -1,0 +1,104 @@
+# RPM spec for Auryn — GTK GUI for streamrip.
+#
+# The package version defaults to APP_VERSION in src/Auryn.py and can be
+# overridden at build time:
+#   rpmbuild -bb --define "auryn_version 0.1.1" --define "_sourcedir $PWD" packaging/rpm/auryn.spec
+#
+# To bump the package version, update APP_VERSION in src/Auryn.py (or pass
+# --define "auryn_version X.Y.Z" on the command line / via the workflow).
+
+%{!?auryn_version: %define auryn_version 0.0.0}
+
+# Disable noisy/unsupported automatic steps for a pure-Python noarch app.
+%global debug_package %{nil}
+%global __brp_mangle_shebangs %{nil}
+
+Name:           auryn
+Version:        %{auryn_version}
+Release:        1%{?dist}
+Summary:        GTK GUI for streamrip
+License:        GPL-3.0-or-later
+URL:            https://github.com/thezupzup/auryn
+BuildArch:      noarch
+
+# streamrip is not reliably packaged across Fedora/openSUSE/RHEL, so we don't
+# hard-require it. Auryn detects a missing 'rip' at runtime and offers to
+# install it via pip/pipx (--user). Adjust the GTK introspection package
+# name per distro family if you build outside Fedora.
+Requires:       python3
+Requires:       python3-gobject
+Requires:       gtk3
+Recommends:     streamrip
+
+%description
+Auryn is a simple GTK 3 graphical front-end for the streamrip command-line
+music downloader. If the streamrip package is not available on your
+distribution, install it with:
+
+    pipx install streamrip
+
+%prep
+# Sources are taken directly from %{_sourcedir} (the checked-out repo root),
+# so there is nothing to unpack.
+
+%build
+# Pure-Python: nothing to compile.
+
+%install
+rm -rf %{buildroot}
+
+install -d %{buildroot}%{_bindir}
+install -d %{buildroot}%{_datadir}/auryn/core
+install -d %{buildroot}%{_datadir}/applications
+install -d %{buildroot}%{_datadir}/icons/hicolor/scalable/apps
+for size in 16 32 48 256; do
+    install -d %{buildroot}%{_datadir}/icons/hicolor/${size}x${size}/apps
+done
+
+# Python sources
+install -m 0644 %{_sourcedir}/src/Auryn.py        %{buildroot}%{_datadir}/auryn/Auryn.py
+install -m 0644 %{_sourcedir}/src/Auryn.ui        %{buildroot}%{_datadir}/auryn/Auryn.ui
+install -m 0644 %{_sourcedir}/src/core/__init__.py %{buildroot}%{_datadir}/auryn/core/__init__.py
+install -m 0644 %{_sourcedir}/src/core/errors.py  %{buildroot}%{_datadir}/auryn/core/errors.py
+install -m 0644 %{_sourcedir}/src/core/status.py  %{buildroot}%{_datadir}/auryn/core/status.py
+
+# Desktop entry
+install -m 0644 %{_sourcedir}/desktop/Auryn.desktop \
+    %{buildroot}%{_datadir}/applications/Auryn.desktop
+
+# Icons
+install -m 0644 %{_sourcedir}/assets/Auryn.svg \
+    %{buildroot}%{_datadir}/icons/hicolor/scalable/apps/Auryn.svg
+for size in 16 32 48 256; do
+    install -m 0644 %{_sourcedir}/assets/Auryn_${size}.png \
+        %{buildroot}%{_datadir}/icons/hicolor/${size}x${size}/apps/Auryn.png
+done
+
+# Launcher: /usr/bin/Auryn matches Exec=Auryn in the desktop file.
+cat > %{buildroot}%{_bindir}/Auryn <<'EOF'
+#!/bin/sh
+exec python3 /usr/share/auryn/Auryn.py "$@"
+EOF
+chmod 0755 %{buildroot}%{_bindir}/Auryn
+ln -s Auryn %{buildroot}%{_bindir}/auryn
+
+%files
+%{_bindir}/Auryn
+%{_bindir}/auryn
+%dir %{_datadir}/auryn
+%dir %{_datadir}/auryn/core
+%{_datadir}/auryn/Auryn.py
+%{_datadir}/auryn/Auryn.ui
+%{_datadir}/auryn/core/__init__.py
+%{_datadir}/auryn/core/errors.py
+%{_datadir}/auryn/core/status.py
+%{_datadir}/applications/Auryn.desktop
+%{_datadir}/icons/hicolor/scalable/apps/Auryn.svg
+%{_datadir}/icons/hicolor/16x16/apps/Auryn.png
+%{_datadir}/icons/hicolor/32x32/apps/Auryn.png
+%{_datadir}/icons/hicolor/48x48/apps/Auryn.png
+%{_datadir}/icons/hicolor/256x256/apps/Auryn.png
+
+%changelog
+* Mon May 11 2026 TheZupZup <noreply@github.com> - 0.1.1-1
+- Initial RPM packaging.

--- a/packaging/rpm/build-rpm.sh
+++ b/packaging/rpm/build-rpm.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Build a noarch .rpm for Auryn using rpmbuild.
+#
+# Usage:
+#   packaging/rpm/build-rpm.sh [VERSION]
+#
+# If VERSION is not provided, it is extracted from src/Auryn.py (APP_VERSION).
+# The resulting .rpm is written to dist/.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+VERSION="${1:-}"
+if [ -z "${VERSION}" ]; then
+    VERSION="$(grep -E '^APP_VERSION\s*=' src/Auryn.py | head -n1 | cut -d'"' -f2 || true)"
+fi
+VERSION="${VERSION:-0.0.0}"
+
+TOPDIR="$(mktemp -d)"
+trap 'rm -rf "${TOPDIR}"' EXIT
+mkdir -p "${TOPDIR}"/{BUILD,BUILDROOT,RPMS,SRPMS,SPECS,SOURCES}
+
+rpmbuild \
+    --define "_topdir ${TOPDIR}" \
+    --define "_sourcedir ${REPO_ROOT}" \
+    --define "auryn_version ${VERSION}" \
+    -bb packaging/rpm/auryn.spec
+
+mkdir -p dist
+find "${TOPDIR}/RPMS" -name '*.rpm' -print0 | xargs -0 -I{} cp {} dist/
+
+echo "Built RPM(s):"
+ls -1 dist/*.rpm


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/linux-packages.yml`: on pushes to `main`, PRs, and `v*` tags, builds both a `.deb` and a `.rpm`, uploads each as a workflow artifact, and on tag builds attaches both to the matching GitHub Release.
- Adds `packaging/debian/build-deb.sh` — a small `dpkg-deb`-based builder.
- Adds `packaging/rpm/auryn.spec` and `packaging/rpm/build-rpm.sh` — a noarch RPM built with `rpmbuild` (installable via `apt install rpm` on Ubuntu runners, so no extra container needed).
- `.gitignore`: ignore `dist/`.

## Layout (identical for both packages)
- `/usr/share/auryn/{Auryn.py,Auryn.ui,core/*}`
- `/usr/bin/Auryn` (matches `Exec=Auryn` in the existing `desktop/Auryn.desktop`) + lowercase `auryn` symlink
- `/usr/share/applications/Auryn.desktop`
- `/usr/share/icons/hicolor/{16,32,48,256,scalable}/apps/Auryn.{png,svg}`

## Metadata
- **Name**: `auryn`
- **Architecture**: `all` (deb) / `noarch` (rpm)
- **Description**: `GTK GUI for streamrip`
- **Version**: from `APP_VERSION` in `src/Auryn.py` for branch/PR builds; from the `vX.Y.Z` tag on tag builds. To bump for non-tag builds, edit `APP_VERSION` in `src/Auryn.py`.
- **Runtime deps (.deb)**: `python3`, `python3-gi`, `gir1.2-gtk-3.0`
- **Runtime deps (.rpm)**: `python3`, `python3-gobject`, `gtk3`
- **streamrip**: `Recommends` only — not reliably packaged across Debian/Ubuntu/Fedora/openSUSE/RHEL. Auryn already detects a missing `rip` at runtime and offers a `pip`/`pipx` install (per `src/Auryn.py`). Download logic untouched.

## Test plan
- [x] `packaging/debian/build-deb.sh` produces `dist/auryn_0.1.1_all.deb` locally; `dpkg-deb --info`/`--contents` look correct
- [x] `packaging/rpm/build-rpm.sh` produces `dist/auryn-0.1.1-1.noarch.rpm` locally; `rpm -qpi`/`-qpl` look correct
- [x] `lintian` / `rpmlint` run as informational steps in CI (non-blocking)
- [ ] CI run on this PR uploads both `.deb` and `.rpm` artifacts
- [ ] A future `vX.Y.Z` tag push attaches both packages to the matching Release

https://claude.ai/code/session_01GcPDtxXpENGeCDSGcBYPpn

---
_Generated by [Claude Code](https://claude.ai/code/session_01GcPDtxXpENGeCDSGcBYPpn)_