### PR TITLE
ci: sync release version across .deb, .rpm, and `auryn --version`

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,89 @@
+# Packaging Auryn
+
+Auryn ships Linux packages built by the `Linux packages` GitHub Actions
+workflow (`.github/workflows/linux-packages.yml`):
+
+- `.deb` for Debian/Ubuntu (built with `dpkg-deb`)
+- `.rpm` for Fedora/openSUSE/RHEL (noarch, built with `rpmbuild`)
+- Windows builds live under `packaging/windows/` (separate flow)
+
+## Single source of truth for the version
+
+The application version is defined **once**, in `src/Auryn.py`:
+
+```python
+APP_VERSION = "0.1.1"
+```
+
+Everything else derives from it:
+
+- `auryn --version` prints `Auryn <APP_VERSION>`
+- The About dialog uses `APP_VERSION`
+- `packaging/debian/build-deb.sh` and `packaging/rpm/build-rpm.sh` read
+  `APP_VERSION` when no version argument is passed
+- CI passes the resolved version (see below) to the build scripts, which
+  then **bake** that value into the installed `Auryn.py` so the running
+  app and the package metadata always match
+
+You should never need to edit a version string in more than one place.
+
+## How CI resolves the version
+
+The `version` job in `linux-packages.yml`:
+
+- On a tag push matching `v*` (e.g. `v2.0.0`) → version is `2.0.0`
+- On any other push / PR → version is the current `APP_VERSION` from
+  `src/Auryn.py`
+
+That value is then passed to both `build-deb.sh` and `build-rpm.sh`,
+which:
+
+1. Use it as the package `Version:` field, and
+2. Rewrite `APP_VERSION` in the bundled `usr/share/auryn/Auryn.py`
+   before packaging.
+
+So a `v2.0.0` tag build produces `auryn_2.0.0_all.deb` /
+`auryn-2.0.0-1.noarch.rpm`, and `auryn --version` from those packages
+prints `Auryn 2.0.0` — even if `APP_VERSION` in `main` still says
+`0.1.1` at the time of the tag.
+
+## Release flow
+
+1. Decide the release version, e.g. `2.0.0`.
+2. (Optional but recommended) Bump `APP_VERSION` in `src/Auryn.py`,
+   commit, and push to `main`. This keeps the dev branch's
+   `--version` honest.
+3. Tag the commit and push the tag:
+
+   ```sh
+   git tag v2.0.0
+   git push origin v2.0.0
+   ```
+
+4. The `Linux packages` workflow runs on the tag:
+   - Builds `auryn_2.0.0_all.deb` and `auryn-2.0.0-1.noarch.rpm`
+   - Uploads each as a workflow artifact
+   - Attaches both files to the GitHub Release for `v2.0.0`
+     (the Release is created if it doesn't already exist)
+
+5. Verify:
+
+   ```sh
+   sudo dpkg -i auryn_2.0.0_all.deb     # or: sudo rpm -i auryn-2.0.0-1.noarch.rpm
+   auryn --version                       # → Auryn 2.0.0
+   ```
+
+## Local builds
+
+You don't need a tag to build locally — the scripts work on any
+checkout:
+
+```sh
+packaging/debian/build-deb.sh            # uses APP_VERSION from src/Auryn.py
+packaging/debian/build-deb.sh 2.0.0-dev  # explicit override
+
+packaging/rpm/build-rpm.sh
+packaging/rpm/build-rpm.sh 2.0.0-dev
+```
+
+Outputs land in `dist/`.

--- a/packaging/debian/build-deb.sh
+++ b/packaging/debian/build-deb.sh
@@ -43,6 +43,11 @@ done
 
 # Python sources
 install -m 0644 src/Auryn.py "${PKG_ROOT}/usr/share/auryn/Auryn.py"
+# Bake the resolved version into the installed Auryn.py so that
+# `auryn --version` and the About dialog report the same version as the
+# package metadata (especially on tag builds where VERSION comes from the tag).
+sed -i -E "s|^APP_VERSION\s*=.*|APP_VERSION = \"${VERSION}\"|" \
+    "${PKG_ROOT}/usr/share/auryn/Auryn.py"
 install -m 0644 src/Auryn.ui "${PKG_ROOT}/usr/share/auryn/Auryn.ui"
 install -m 0644 src/core/__init__.py "${PKG_ROOT}/usr/share/auryn/core/__init__.py"
 install -m 0644 src/core/errors.py "${PKG_ROOT}/usr/share/auryn/core/errors.py"

--- a/packaging/rpm/auryn.spec
+++ b/packaging/rpm/auryn.spec
@@ -57,6 +57,10 @@ done
 
 # Python sources
 install -m 0644 %{_sourcedir}/src/Auryn.py        %{buildroot}%{_datadir}/auryn/Auryn.py
+# Bake the resolved version into the installed Auryn.py so that
+# `auryn --version` and the About dialog match the package metadata.
+sed -i -E "s|^APP_VERSION\s*=.*|APP_VERSION = \"%{auryn_version}\"|" \
+    %{buildroot}%{_datadir}/auryn/Auryn.py
 install -m 0644 %{_sourcedir}/src/Auryn.ui        %{buildroot}%{_datadir}/auryn/Auryn.ui
 install -m 0644 %{_sourcedir}/src/core/__init__.py %{buildroot}%{_datadir}/auryn/core/__init__.py
 install -m 0644 %{_sourcedir}/src/core/errors.py  %{buildroot}%{_datadir}/auryn/core/errors.py

--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -1851,7 +1851,7 @@ class AurynApp:
         dlg = Gtk.AboutDialog()
         dlg.set_transient_for(self.window)
         dlg.set_program_name("Auryn")
-        dlg.set_version("v0.1.1")
+        dlg.set_version(f"v{APP_VERSION}")
         dlg.set_comments("GUI wrapper for streamrip\nQobuz • Deezer • Tidal • SoundCloud")
         dlg.set_copyright("© 2025 TheZupZup")
         dlg.set_license_type(Gtk.License.GPL_3_0)


### PR DESCRIPTION
## Summary
Makes `APP_VERSION` in `src/Auryn.py` the single source of truth for the application version, and has the packaging pipeline bake the resolved release version into the installed `Auryn.py` so the package metadata and the running app always agree.

## Changes
- **`src/Auryn.py`**: About dialog now reads `APP_VERSION` instead of the hardcoded `"v0.1.1"`. (`auryn --version` already used `APP_VERSION`.)
- **`packaging/debian/build-deb.sh`** and **`packaging/rpm/auryn.spec`**: after copying `Auryn.py` into the staging area, rewrite its `APP_VERSION` line to the resolved package version. The existing `linux-packages.yml` `version` job already passes the tag (e.g. `2.0.0`) to both builders on `v*` tag builds, so no workflow changes are needed.
- **`packaging/README.md`** (new): documents the release flow.

## How the version is resolved
| Trigger | Version used |
|---|---|
| Push to `main` / PR | `APP_VERSION` from `src/Auryn.py` |
| Tag `vX.Y.Z` | `X.Y.Z` from the tag (overrides `APP_VERSION` in the installed file too) |

So a `v2.0.0` tag produces `auryn_2.0.0_all.deb` / `auryn-2.0.0-1.noarch.rpm`, and `auryn --version` from those packages prints `Auryn 2.0.0` — even if `APP_VERSION` on `main` is still `0.1.1`.

## Release flow (also in `packaging/README.md`)
1. (Optional) Bump `APP_VERSION` in `src/Auryn.py` and push to `main`.
2. Tag and push:
   ```sh
   git tag v2.0.0
   git push origin v2.0.0
   ```
3. The `Linux packages` workflow builds `.deb` + `.rpm`, uploads them as artifacts, and attaches them to the GitHub Release.

## Test plan
- [x] Local `packaging/debian/build-deb.sh 2.0.0` produces `auryn_2.0.0_all.deb` with `APP_VERSION = "2.0.0"` baked into the bundled `Auryn.py`
- [x] Local `packaging/rpm/build-rpm.sh 2.0.0` produces `auryn-2.0.0-1.noarch.rpm` with the same `APP_VERSION` rewrite
- [x] `python3 /usr/share/auryn/Auryn.py --version` from the extracted `.deb` prints `Auryn 2.0.0`
- [ ] CI run on this PR builds artifacts using `APP_VERSION` from `src/Auryn.py`
- [ ] A future `vX.Y.Z` tag push produces packages whose metadata and `auryn --version` both report `X.Y.Z`

https://claude.ai/code/session_01GcPDtxXpENGeCDSGcBYPpn

---
_Generated by [Claude Code](https://claude.ai/code/session_01GcPDtxXpENGeCDSGcBYPpn)_