### PR TITLE
ci: consolidate Linux packaging into a single workflow

### DIFF
--- a/.github/workflows/linux-packages.yml
+++ b/.github/workflows/linux-packages.yml
@@ -1,0 +1,203 @@
+name: Linux packages
+
+# Builds Auryn's Linux package formats in a single workflow:
+#   - .deb  (Debian/Ubuntu/Linux Mint, arch: all)        via dpkg-deb
+#   - .rpm  (Fedora/openSUSE/RHEL-style, arch: noarch)   via rpmbuild
+#
+# On every push to main and every PR we build both packages and upload them
+# as workflow artifacts so reviewers can install/test them. On version tags
+# (`v*`) we additionally attach the built packages to the matching GitHub
+# Release.
+#
+# Versioning:
+#   - On a `v<X.Y.Z>` tag, the package version is `<X.Y.Z>`.
+#   - Otherwise we read APP_VERSION from src/Auryn.py.
+#   The resolved version is also baked into the installed Auryn.py so that
+#   `auryn --version` matches the package metadata.
+
+on:
+  push:
+    branches: [ "main" ]
+    tags: [ "v*" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: write
+
+jobs:
+  version:
+    name: Resolve package version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: resolve
+        name: Resolve version from tag or APP_VERSION
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          else
+            VERSION="$(grep -E '^APP_VERSION\s*=' src/Auryn.py | head -n1 | cut -d'"' -f2)"
+          fi
+          if [ -z "${VERSION}" ]; then
+            echo "Could not resolve version" >&2
+            exit 1
+          fi
+          echo "Resolved version: ${VERSION}"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+
+  build-deb:
+    name: Build .deb (arch all)
+    needs: version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            dpkg-dev \
+            python3 \
+            lintian
+
+      - name: Sanity-check sources (py_compile)
+        run: python3 -m py_compile src/Auryn.py
+
+      - name: Build .deb
+        run: packaging/debian/build-deb.sh "${{ needs.version.outputs.version }}"
+
+      - name: Inspect built package (dpkg-deb --info)
+        run: |
+          for pkg in dist/*.deb; do
+            echo "::group::dpkg-deb --info ${pkg}"
+            dpkg-deb --info "${pkg}"
+            echo "::endgroup::"
+            echo "::group::dpkg-deb --contents ${pkg}"
+            dpkg-deb --contents "${pkg}"
+            echo "::endgroup::"
+          done
+
+      - name: Verify arch and baked --version
+        run: |
+          pkg="$(ls dist/*.deb | head -n1)"
+          arch="$(dpkg-deb --field "${pkg}" Architecture)"
+          if [ "${arch}" != "all" ]; then
+            echo "Expected Architecture: all, got: ${arch}" >&2
+            exit 1
+          fi
+          # The build script bakes APP_VERSION into the installed Auryn.py.
+          # Extract it from the package and confirm it matches the resolved version.
+          tmp="$(mktemp -d)"
+          dpkg-deb -x "${pkg}" "${tmp}"
+          baked="$(grep -E '^APP_VERSION\s*=' "${tmp}/usr/share/auryn/Auryn.py" \
+                   | head -n1 | cut -d'"' -f2)"
+          want="${{ needs.version.outputs.version }}"
+          if [ "${baked}" != "${want}" ]; then
+            echo "Baked APP_VERSION (${baked}) does not match package version (${want})" >&2
+            exit 1
+          fi
+          echo "OK: .deb Architecture=all, APP_VERSION=${baked}"
+
+      - name: Lint .deb (informational)
+        run: lintian --no-tag-display-limit dist/*.deb || true
+
+      - name: Upload .deb artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: auryn-deb-${{ needs.version.outputs.version }}
+          path: dist/*.deb
+          if-no-files-found: error
+
+  build-rpm:
+    name: Build .rpm (noarch)
+    needs: version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            rpm \
+            python3 \
+            rpmlint
+
+      - name: Sanity-check sources (py_compile)
+        run: python3 -m py_compile src/Auryn.py
+
+      - name: Build .rpm
+        run: packaging/rpm/build-rpm.sh "${{ needs.version.outputs.version }}"
+
+      - name: Inspect built package (rpm -qip)
+        run: |
+          for pkg in dist/*.rpm; do
+            echo "::group::rpm -qip ${pkg}"
+            rpm -qip "${pkg}"
+            echo "::endgroup::"
+            echo "::group::rpm -qlp ${pkg}"
+            rpm -qlp "${pkg}"
+            echo "::endgroup::"
+          done
+
+      - name: Verify arch and baked --version
+        run: |
+          pkg="$(ls dist/*.rpm | head -n1)"
+          arch="$(rpm -qp --qf '%{ARCH}\n' "${pkg}")"
+          if [ "${arch}" != "noarch" ]; then
+            echo "Expected ARCH: noarch, got: ${arch}" >&2
+            exit 1
+          fi
+          # Extract the bundled Auryn.py from the .rpm and confirm the
+          # baked APP_VERSION matches the resolved package version.
+          tmp="$(mktemp -d)"
+          ( cd "${tmp}" && rpm2cpio "${GITHUB_WORKSPACE}/${pkg}" \
+              | cpio -idm --quiet )
+          baked="$(grep -E '^APP_VERSION\s*=' "${tmp}/usr/share/auryn/Auryn.py" \
+                   | head -n1 | cut -d'"' -f2)"
+          want="${{ needs.version.outputs.version }}"
+          if [ "${baked}" != "${want}" ]; then
+            echo "Baked APP_VERSION (${baked}) does not match package version (${want})" >&2
+            exit 1
+          fi
+          echo "OK: .rpm ARCH=noarch, APP_VERSION=${baked}"
+
+      - name: Lint .rpm (informational)
+        run: rpmlint dist/*.rpm || true
+
+      - name: Upload .rpm artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: auryn-rpm-${{ needs.version.outputs.version }}
+          path: dist/*.rpm
+          if-no-files-found: error
+
+  release:
+    name: Attach packages to GitHub Release
+    needs: [version, build-deb, build-rpm]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download .deb artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: auryn-deb-${{ needs.version.outputs.version }}
+          path: dist
+
+      - name: Download .rpm artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: auryn-rpm-${{ needs.version.outputs.version }}
+          path: dist
+
+      - name: Attach packages to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/*.deb
+            dist/*.rpm
+          fail_on_unmatched_files: true

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -7,6 +7,16 @@ workflow (`.github/workflows/linux-packages.yml`):
 - `.rpm` for Fedora/openSUSE/RHEL (noarch, built with `rpmbuild`)
 - Windows builds live under `packaging/windows/` (separate flow)
 
+## streamrip is not a hard dependency
+
+`streamrip` is **not** packaged reliably across Debian/Ubuntu, Fedora,
+openSUSE, or RHEL, so neither the `.deb` nor the `.rpm` hard-depends on
+it — both list it only as `Recommends:`. When Auryn starts up and the
+`rip` executable is missing from `PATH`, the GUI offers to install
+streamrip for the current user via `pip install --user streamrip`
+(`pipx install streamrip` also works). See
+`_offer_streamrip_install` in `src/Auryn.py`.
+
 ## Single source of truth for the version
 
 The application version is defined **once**, in `src/Auryn.py`:


### PR DESCRIPTION
## Summary

Restores a single, consolidated CI workflow that builds every Linux package format for Auryn from one place:

- `.deb` (Debian/Ubuntu/Linux Mint, `Architecture: all`) via `dpkg-deb`
- `.rpm` (Fedora/openSUSE/RHEL-style, `BuildArch: noarch`) via `rpmbuild`

Both packages are uploaded as workflow artifacts on every push to `main` and every PR, and attached to the matching GitHub Release on `v*` tag builds. The Python app CI (`python-app.yml`) is left untouched, and packaging files stay under `packaging/`.

## What's in this PR

- `.github/workflows/linux-packages.yml` — new consolidated workflow with three jobs:
  - `version` — resolves the package version from the tag on `v<X.Y.Z>` builds, otherwise from `APP_VERSION` in `src/Auryn.py`.
  - `build-deb` — installs `dpkg-dev` + `lintian`, runs `python3 -m py_compile src/Auryn.py`, builds the package, then runs `dpkg-deb --info` / `--contents`, asserts `Architecture: all`, and verifies the baked `APP_VERSION` matches the resolved version.
  - `build-rpm` — installs `rpm` + `rpmlint`, runs `py_compile`, builds the package, then runs `rpm -qip` / `-qlp`, asserts `ARCH: noarch`, and verifies the baked `APP_VERSION`.
  - `release` — runs only on `refs/tags/v*` and attaches both packages to the GitHub Release with `softprops/action-gh-release@v2`.
- `packaging/README.md` — adds a short section documenting that streamrip is intentionally `Recommends:` only (not packaged reliably across distros) and that Auryn offers to install it via `pip install --user streamrip` on first run when `rip` is missing.

## Versioning behavior

- `v0.1.2` / `v2.0.0` tag → package version is `0.1.2` / `2.0.0`.
- Non-tag builds use `APP_VERSION` from `src/Auryn.py`.
- The resolved version is baked into the installed `Auryn.py` by the build scripts, so `auryn --version` always matches the package metadata. CI asserts this after build.

## Preserved

- Desktop metadata: `desktop/Auryn.desktop`, `assets/Auryn.svg` and `Auryn_{16,32,48,256}.png` are all installed into the standard `hicolor` icon theme paths and `/usr/share/applications/Auryn.desktop` by both packages.
- Download / install logic in the app is untouched.
- Windows packaging under `packaging/windows/` is untouched.
- `python-app.yml` (lint + tests) is untouched.

## Notes

- `linux-packages.yml` and `deb-package.yml` were previously deleted on `main`; this PR is the consolidated replacement, so there are no duplicate workflows to remove.
- `lintian` / `rpmlint` are run informationally (`|| true`) — they are useful signal in PR logs but don't fail the job.

## Test plan

- [x] CI: `build-deb` succeeds and uploads `auryn-deb-<version>` artifact — job `Build .deb (arch all)` ✅ success on run `25672917675`, artifact `auryn-deb-0.1.1` (`if-no-files-found: error` ensures upload non-empty).
- [x] CI: `build-rpm` succeeds and uploads `auryn-rpm-<version>` artifact — job `Build .rpm (noarch)` ✅ success on run `25672917675`, artifact `auryn-rpm-0.1.1`.
- [x] `dpkg-deb --info` confirms `Architecture: all`, `Depends: python3, python3-gi, gir1.2-gtk-3.0`, `Recommends: streamrip` — verified locally on `dist/auryn_0.1.1_all.deb`:

  ```
  Package: auryn
  Version: 0.1.1
  Architecture: all
  Depends: python3, python3-gi, gir1.2-gtk-3.0
  Recommends: streamrip
  ```

- [x] `rpm -qip` confirms `Architecture: noarch`, `Requires: python3 python3-gobject gtk3`, `Recommends: streamrip` — verified locally on `dist/auryn-0.1.1-1.noarch.rpm`:

  ```
  Architecture: noarch
  Requires    : /bin/sh, gtk3, python3, python3-gobject, rpmlib(...)
  Recommends  : streamrip
  ```

  (`/bin/sh` and the `rpmlib(...)` entries are auto-added by `rpmbuild`; the explicit `Requires:` lines from `auryn.spec` are all present.)
- [x] Local install of `.deb` → `auryn --version` prints `Auryn 0.1.1`. Verified via `sudo dpkg -i dist/auryn_0.1.1_all.deb` on Ubuntu 24.04; `/usr/bin/auryn` symlinks to `/usr/bin/Auryn` which `exec python3 /usr/share/auryn/Auryn.py`s.
- [x] Local install of `.rpm` → `auryn --version` prints `Auryn 0.1.1`. Verified via `sudo rpm -i --nodeps --force dist/auryn-0.1.1-1.noarch.rpm` (Ubuntu host — `--nodeps` because Ubuntu doesn't satisfy `gtk3`/`python3-gobject` by RPM name, but the runtime deps from the .deb install were present).
- [ ] Tag dry-run: pushing a `v0.1.2` tag attaches `auryn_0.1.2_all.deb` and `auryn-0.1.2-1.noarch.rpm` to the GitHub Release — not exercised in this PR (would require pushing a real tag); the `release` job has the correct `if: startsWith(github.ref, 'refs/tags/v')` guard and was skipped on this PR run as expected.

https://claude.ai/code/session_01YWxiFGBG3xkRV3av1byt3g