### PR TITLE
ci(windows): fix --onedir build path, discover Auryn.exe dynamically

### DIFF
--- a/.github/workflows/windows-exe.yml
+++ b/.github/workflows/windows-exe.yml
@@ -153,24 +153,48 @@ jobs:
           pyinstaller --noconfirm --clean --log-level=INFO \
               packaging/windows/Auryn.spec
 
-      - name: Inspect dist/ after PyInstaller
+      - name: Inspect dist/ and locate Auryn.exe
+        id: inspect_dist
         if: always()
         run: |
           set +e
           echo "--- pyinstaller --version ---"
           pyinstaller --version 2>&1 || true
           echo
+
           echo "--- dist/ tree (depth 5) ---"
           if [ -d dist ]; then
             find dist -maxdepth 5 | sort
             echo
             echo "--- sizes ---"
             du -sh dist 2>/dev/null
-            [ -d dist/Auryn ]                     && du -sh dist/Auryn
-            [ -f dist/Auryn/Auryn.exe ]           && du -h dist/Auryn/Auryn.exe
-            [ -d dist/Auryn/_internal ]           && du -sh dist/Auryn/_internal
           else
             echo "(dist/ does not exist — PyInstaller did not produce any output)"
+          fi
+          echo
+
+          # Discover the actual PyInstaller output path instead of assuming
+          # dist/Auryn/. Different PyInstaller versions, or a spec/version
+          # mismatch, can land the executable at a different location; the
+          # validation and upload steps below need the real path.
+          echo "--- locating Auryn.exe ---"
+          exe_path=""
+          if [ -d dist ]; then
+            exe_path="$(find dist -maxdepth 4 -type f -iname 'Auryn.exe' -print 2>/dev/null | head -n1)"
+          fi
+          if [ -n "$exe_path" ]; then
+            bundle_dir="$(dirname "$exe_path")"
+            echo "Found Auryn.exe : ${exe_path}"
+            echo "Bundle root     : ${bundle_dir}"
+            du -h  "$exe_path"   2>/dev/null
+            du -sh "$bundle_dir" 2>/dev/null
+            [ -d "$bundle_dir/_internal" ] && du -sh "$bundle_dir/_internal"
+            printf 'exe_path=%s\n'   "$exe_path"   >> "$GITHUB_OUTPUT"
+            printf 'bundle_dir=%s\n' "$bundle_dir" >> "$GITHUB_OUTPUT"
+          else
+            echo "Auryn.exe was NOT produced under dist/."
+            printf 'exe_path=\n'   >> "$GITHUB_OUTPUT"
+            printf 'bundle_dir=\n' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Validate --onedir bundle (best-effort report)
@@ -190,20 +214,32 @@ jobs:
               fail=1
             fi
           }
-          # Auryn.exe is always at the top level of the bundle regardless of
-          # PyInstaller version.
-          check f dist/Auryn/Auryn.exe                  "Auryn.exe"
 
-          # PyInstaller 6+ defaults onedir data into dist/Auryn/_internal/;
-          # older versions (and our spec's `contents_directory="."`) put it
-          # flat under dist/Auryn/. Detect which layout was produced and
-          # validate against that root. Either layout works at runtime
-          # because the GTK runtime hook resolves paths from sys._MEIPASS.
-          if [ -d dist/Auryn/_internal ] && [ ! -f dist/Auryn/Auryn.ui ]; then
-            ROOT=dist/Auryn/_internal
+          EXE_PATH="${{ steps.inspect_dist.outputs.exe_path }}"
+          BUNDLE_DIR="${{ steps.inspect_dist.outputs.bundle_dir }}"
+
+          # No Auryn.exe means PyInstaller didn't produce a bundle at all;
+          # there is nothing to validate. Mark the run as failed and let the
+          # final "Fail job" step surface it.
+          if [ -z "$EXE_PATH" ] || [ -z "$BUNDLE_DIR" ]; then
+            echo "::warning::Auryn.exe was not produced by PyInstaller; skipping bundle layout checks."
+            echo "onedir_failed=1" >> "$GITHUB_OUTPUT"
+            echo "bundle_dir="     >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          check f "$EXE_PATH" "Auryn.exe"
+
+          # PyInstaller 6+ defaults onedir data into <bundle>/_internal/;
+          # the spec's `contents_directory="."` on COLLECT puts it flat under
+          # <bundle>/. Detect which layout PyInstaller actually produced and
+          # validate against it. Either layout works at runtime because the
+          # GTK runtime hook resolves paths from sys._MEIPASS.
+          if [ -d "$BUNDLE_DIR/_internal" ] && [ ! -f "$BUNDLE_DIR/Auryn.ui" ]; then
+            ROOT="$BUNDLE_DIR/_internal"
             echo "Detected PyInstaller _internal/ layout; validating under ${ROOT}/"
           else
-            ROOT=dist/Auryn
+            ROOT="$BUNDLE_DIR"
             echo "Detected flat layout; validating under ${ROOT}/"
           fi
           echo "bundle_root=${ROOT}" >> "$GITHUB_OUTPUT"
@@ -219,17 +255,21 @@ jobs:
           else
             echo "Bundle layout OK."
           fi
-          echo "onedir_failed=${fail}" >> "$GITHUB_OUTPUT"
+          echo "onedir_failed=${fail}"    >> "$GITHUB_OUTPUT"
+          echo "bundle_dir=${BUNDLE_DIR}" >> "$GITHUB_OUTPUT"
 
       - name: Upload --onedir bundle (only if validation passed)
         # Per task contract: do not upload an artifact that failed validation.
         # The source-fallback zip below is always uploaded, so testers still
         # have something to download even on a broken --onedir run.
-        if: ${{ always() && steps.build_onedir.outcome == 'success' && steps.validate.outputs.onedir_failed == '0' && hashFiles('dist/Auryn/Auryn.exe') != '' }}
+        # Upload from the bundle directory discovered by inspect_dist rather
+        # than a hardcoded path, so the artifact always contains the real
+        # Auryn.exe wherever PyInstaller produced it.
+        if: ${{ always() && steps.build_onedir.outcome == 'success' && steps.validate.outputs.onedir_failed == '0' && steps.validate.outputs.bundle_dir != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: auryn-windows-onedir-${{ steps.version.outputs.version }}
-          path: dist/Auryn/
+          path: ${{ steps.validate.outputs.bundle_dir }}/
           if-no-files-found: error
 
       - name: Build source-fallback zip (always)

--- a/packaging/windows/Auryn.spec
+++ b/packaging/windows/Auryn.spec
@@ -152,11 +152,6 @@ exe = EXE(
     codesign_identity=None,
     entitlements_file=None,
     icon=icon_arg,
-    # PyInstaller 6+ defaults onedir collected files into a `_internal/`
-    # subdirectory; "." restores the flat layout this spec, the runtime hook,
-    # and the CI validation all assume (Auryn.ui, assets/, lib/, share/ next
-    # to Auryn.exe). Ignored on PyInstaller <6.
-    contents_directory=".",
 )
 
 coll = COLLECT(
@@ -168,4 +163,12 @@ coll = COLLECT(
     upx=False,
     upx_exclude=[],
     name="Auryn",
+    # PyInstaller 6+ defaults onedir collected files into a `_internal/`
+    # subdirectory; "." restores the flat layout (Auryn.ui, assets/, lib/,
+    # share/ sit next to Auryn.exe). `contents_directory` is a COLLECT
+    # kwarg in PyInstaller >=6 — passing it to EXE silently fails to set
+    # the layout and, in some versions, aborts analysis entirely so no
+    # Auryn.exe is produced. The runtime hook and the CI validation both
+    # support either layout, so this only controls the on-disk shape.
+    contents_directory=".",
 )


### PR DESCRIPTION
## Summary

Fixes the experimental Windows packaging workflow that was failing with
`One or more expected files are missing from the --onedir bundle` and
producing an artifact with no `Auryn.exe`.

### Root cause

`packaging/windows/Auryn.spec` was passing `contents_directory="."` to
`EXE()`, but on PyInstaller >=6 that is a `COLLECT` kwarg. On `EXE` it
either silently fails to set the flat layout (so `COLLECT` falls back to
`_internal/`) or, depending on version, aborts analysis so no
`Auryn.exe` is produced at all. The workflow then validated and uploaded
from a hardcoded `dist/Auryn/` path, so when PyInstaller produced
something different — or nothing — both the validation and the artifact
upload missed the real bundle.

### Changes

**`packaging/windows/Auryn.spec`**
- Move `contents_directory="."` from `EXE()` to `COLLECT()` so the flat
  layout actually takes effect and analysis isn't aborted by an unknown
  kwarg.

**`.github/workflows/windows-exe.yml`** (still experimental, source‑fallback
zip still always uploaded, job still fails if `--onedir` is unusable)
- New `Inspect dist/ and locate Auryn.exe` step: prints the `dist/`
  tree, then uses `find` to discover the real `Auryn.exe` path and
  exports `exe_path` / `bundle_dir` as step outputs.
- `Validate --onedir bundle` consumes those outputs and validates against
  the discovered bundle directory, auto‑detecting flat vs `_internal/`
  layout from there instead of hardcoding `dist/Auryn/`. If `Auryn.exe`
  isn't found at all, validation marks the run failed and the final
  `Fail job` step still surfaces the failure (no faked success).
- Artifact upload uses the discovered `bundle_dir` as its `path`, so the
  uploaded artifact always contains the real `Auryn.exe` wherever
  PyInstaller produced it.

Linux packaging workflow (`linux-packages.yml`) is untouched.

## Test plan

- [ ] `Windows packaging (experimental)` workflow runs to completion on
      this branch (via `workflow_dispatch` or a PR trigger touching
      `packaging/windows/**`).
- [ ] CI log for the `Inspect dist/ and locate Auryn.exe` step shows the
      `dist/` tree and a `Found Auryn.exe : …` line.
- [ ] `auryn-windows-onedir-<version>` artifact is produced and contains
      `Auryn.exe` at its top level.
- [ ] `auryn-windows-source-<version>.zip` artifact is still produced
      regardless of the `--onedir` outcome.
- [ ] If `Auryn.exe` is somehow not produced, the job still fails (no
      faked success), and the `Inspect dist/` step makes the cause
      visible.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WTxhx7NdcSQixP4GWk5Jmx)_