### PR TITLE
Fix Windows streamrip subprocess UTF-8 encoding

### DIFF
--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -1459,6 +1459,12 @@ class AurynApp:
         env["PYTHONUNBUFFERED"] = "1"
         env["TERM"] = "xterm-256color"
         env["FORCE_COLOR"] = "1"
+        # streamrip prints Unicode track/artist names to stdout. On Windows the
+        # default process encoding is cp1252, so streamrip itself raises
+        # UnicodeEncodeError ('charmap' codec). Forcing UTF-8 mode in the child
+        # is a no-op on Linux and prevents the crash on Windows.
+        env["PYTHONUTF8"] = "1"
+        env["PYTHONIOENCODING"] = "utf-8"
 
         if IS_WINDOWS:
             self._run_download_windows(rip_path, url, env)
@@ -1542,6 +1548,8 @@ class AurynApp:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 bufsize=1,
                 env=env,
                 creationflags=creation_flags,
@@ -2363,6 +2371,10 @@ class AurynApp:
 
             env = os.environ.copy()
             env["PYTHONUNBUFFERED"] = "1"
+            # Same Windows cp1252 issue as the download path: force UTF-8 mode
+            # in the child so streamrip can print Unicode without crashing.
+            env["PYTHONUTF8"] = "1"
+            env["PYTHONIOENCODING"] = "utf-8"
             creationflags = (getattr(subprocess, "CREATE_NO_WINDOW", 0)
                              if IS_WINDOWS else 0)
             try:
@@ -2370,6 +2382,7 @@ class AurynApp:
                     [rip, "url", TIDAL_LOGIN_PROBE_URL],
                     stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                     stdin=subprocess.DEVNULL, text=True, bufsize=1,
+                    encoding="utf-8", errors="replace",
                     env=env, creationflags=creationflags,
                 )
             except Exception as exc:


### PR DESCRIPTION
## Summary

On Windows, Deezer (and other) downloads could crash with:

```
UnicodeEncodeError: 'charmap' codec can't encode character
```

This happens because `streamrip` writes Unicode track/artist names to stdout while the default Windows process/console encoding is `cp1252`.

## Changes

- Add `PYTHONUTF8=1` and `PYTHONIOENCODING=utf-8` to the subprocess environment used when launching `rip`, for both:
  - the main download flow (shared env, covers the Linux PTY path and the Windows `Popen` path)
  - the TIDAL login auth probe (also runs `rip url ...`)
- Decode captured stdout as `utf-8` with `errors="replace"` on the Windows download reader and the TIDAL auth probe (the Linux PTY path already decoded with `utf-8`/`replace`).
- Existing environment variables are preserved (`os.environ.copy()` + key additions).
- The change is a safe no-op on Linux and prevents the crash on Windows.
- Download logic is unchanged. No new dependencies.

## Test plan

- [x] `python3 -m py_compile src/Auryn.py` passes
- [ ] On Windows: download a Deezer release whose metadata contains non-cp1252 Unicode characters and confirm no `UnicodeEncodeError` and that logs render readably
- [ ] On Linux: confirm downloads still work and logs are unaffected

https://claude.ai/code/session_01GPVrpFkbsE1GVuYcwggnJW

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPVrpFkbsE1GVuYcwggnJW)_