### PR TITLE
Protect album metadata sidebar against regressions

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,13 @@
+"""Pytest bootstrap: expose the GTK-free ``core`` package to tests.
+
+Auryn's source lives under ``src/`` and adds that directory to
+``sys.path`` at runtime. Mirror that here so ``from core import metadata``
+resolves during ``pytest`` without importing the GTK application module.
+"""
+
+import os
+import sys
+
+SRC = os.path.join(os.path.dirname(os.path.abspath(__file__)), "src")
+if SRC not in sys.path:
+    sys.path.insert(0, SRC)

--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -25,6 +25,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from core.errors import parse_streamrip_error
 from core.status import build_status_markup
 from core import tidal_auth
+from core import metadata
 
 APP_NAME = "Auryn"
 APP_VERSION = "0.1.1"
@@ -958,73 +959,126 @@ class AurynApp:
         self._run_download(url, quality)
 
     # ── Métadonnées ───────────────────────────────────────────────────────────
+    #
+    # PROTECTED UX SURFACE — the right-side album sidebar (cover art + artist /
+    # album / quality / track count / UPC / release date) is a critical,
+    # user-facing feature. It must NEVER crash the UI or the streamrip log
+    # pump, even with partial/None API payloads or a renamed .ui widget.
+    #
+    # Rules for anyone touching this section:
+    #   * Route every sidebar text write through self._set_meta(); never call
+    #     a label's .set_markup() directly from parsing code.
+    #   * Parse/normalize API payloads in core.metadata (GTK-free, tested).
+    #   * If cover art is missing/fails, leave the existing placeholder.
+    # See tests/test_metadata.py for the regression guarantees.
+
+    def _get_meta_text(self, key):
+        """Read a sidebar label's current text, tolerating a missing widget."""
+        widget = self._meta.get(key)
+        if widget is None:
+            return ""
+        try:
+            return widget.get_text()
+        except Exception:
+            return ""
+
+    def _set_meta(self, key, value, overwrite=True, limit=metadata.META_MAX_LEN):
+        """Safely write *value* into the sidebar label for *key*.
+
+        Defensive by design:
+          * unknown key / renamed-or-missing widget  -> no-op (never raises)
+          * empty / falsy value                      -> keep placeholder
+          * overwrite=False                          -> only fill an empty
+            field (matches the log-scraping "don't clobber" behaviour)
+
+        A single broken widget must not take down metadata parsing or the
+        streamrip output pump, so the GTK call is guarded too.
+        """
+        markup = metadata.build_meta_markup(value, limit)
+        if markup is None:
+            return
+        widget = self._meta.get(key)
+        if widget is None:
+            return
+        if not overwrite:
+            current = self._get_meta_text(key)
+            if current not in ("—", ""):
+                return
+        try:
+            widget.set_markup(markup)
+        except Exception:
+            pass
 
     def _apply_deezer_meta(self, data):
-        def sm(key, value):
-            if value:
-                txt = str(value).strip()[:28].replace("&","&amp;").replace("<","&lt;")
-                self._meta[key].set_markup(f'<span foreground="#e8e8e8" size="small">{txt}</span>')
-        artist = data.get("artist", {}).get("name", "")
-        album  = data.get("title", "")
-        sm("Album Artist",  artist)
-        sm("Album",         album)
-        sm("Total Tracks",  data.get("nb_tracks", ""))
-        sm("UPC",           data.get("upc", ""))
-        sm("Release Date",  data.get("release_date", ""))
-        sm("Album Quality", "FLAC 16-bit / 44.1 kHz")
-        title = self._format_history_title(artist, album)
+        fields = metadata.deezer_album_fields(data)
+        # Deezer values are kept slightly shorter to fit the historical layout.
+        self._set_meta("Album Artist",  fields["artist"],       limit=28)
+        self._set_meta("Album",         fields["album"],        limit=28)
+        self._set_meta("Total Tracks",  fields["total_tracks"], limit=28)
+        self._set_meta("UPC",           fields["upc"],          limit=28)
+        self._set_meta("Release Date",  fields["release_date"], limit=28)
+        self._set_meta("Album Quality", fields["quality"],      limit=28)
+        title = self._format_history_title(fields["artist"], fields["album"])
         self._history_set_title(self._current_history_entry, title)
         self._queue_set_title(self._current_queue_item, title)
-        cover_url = data.get("cover_xl") or data.get("cover_big") or data.get("cover_medium")
-        if cover_url:
-            threading.Thread(target=self._load_cover, args=(cover_url,), daemon=True).start()
+        if fields["cover_url"]:
+            threading.Thread(target=self._load_cover,
+                              args=(fields["cover_url"],), daemon=True).start()
 
     def _apply_qobuz_meta(self, data):
-        def sm(key, value):
-            if value:
-                txt = str(value).strip()[:30].replace("&","&amp;").replace("<","&lt;")
-                self._meta[key].set_markup(f'<span foreground="#e8e8e8" size="small">{txt}</span>')
-        artist = data.get("artist", {}).get("name", "") or data.get("performer", {}).get("name", "")
-        album  = data.get("title", "")
-        sm("Album Artist",  artist)
-        sm("Album",         album)
-        sm("Total Tracks",  data.get("tracks_count", data.get("tracks", {}).get("total", "")))
-        sm("UPC",           data.get("upc", ""))
-        sm("Release Date",  (data.get("release_date_original") or data.get("released_at") or "")[:10])
-        title = self._format_history_title(artist, album)
+        fields = metadata.qobuz_album_fields(data)
+        self._set_meta("Album Artist",  fields["artist"])
+        self._set_meta("Album",         fields["album"])
+        self._set_meta("Total Tracks",  fields["total_tracks"])
+        self._set_meta("UPC",           fields["upc"])
+        self._set_meta("Release Date",  fields["release_date"])
+        self._set_meta("Album Quality", fields["quality"])
+        title = self._format_history_title(fields["artist"], fields["album"])
         self._history_set_title(self._current_history_entry, title)
         self._queue_set_title(self._current_queue_item, title)
-        max_q = data.get("maximum_sampling_rate", 0)
-        max_b = data.get("maximum_bit_depth", 0)
-        if max_q and max_b:
-            sm("Album Quality", f"FLAC {max_b}-bit / {max_q} kHz")
-        elif data.get("hires_streamable"):
-            sm("Album Quality", "Hi-Res FLAC")
-        img = data.get("image", {})
-        cover_url = img.get("large") or img.get("small") or img.get("thumbnail", "")
-        if cover_url:
-            cover_url = re.sub(r'_\d+\.jpg', '_max.jpg', cover_url)
-            cover_fallback = re.sub(r'_\d+\.jpg', '_600.jpg', cover_url.replace('_max.jpg', '_600.jpg'))
+        if fields["cover_url"]:
             threading.Thread(
                 target=self._load_cover_with_fallback,
-                args=(cover_url, cover_fallback), daemon=True
+                args=(fields["cover_url"], fields["cover_fallback"]),
+                daemon=True,
             ).start()
+
+    def _set_cover_present_label(self):
+        """Brighten the caption to signal that real cover art is shown."""
+        if self.cover_lbl is None:
+            return
+        try:
+            self.cover_lbl.set_markup(
+                '<span foreground="#888888" size="small" letter_spacing="200">COVER</span>')
+        except Exception:
+            pass
+
+    def _show_cover_pixbuf(self, pb):
+        """Display downloaded cover art, or fall back to the placeholder.
+
+        Always leaves the sidebar in a stable state: a successful pixbuf is
+        shown with the brightened caption; a failure keeps the existing
+        neutral placeholder tile and caption rather than a blank slot.
+        """
+        if pb and self.cover_img is not None:
+            try:
+                self.cover_img.set_from_pixbuf(pb)
+                self._set_cover_present_label()
+                return
+            except Exception:
+                pass
+        self._set_placeholder_cover()
+        self._set_cover_placeholder_label()
 
     def _load_cover_with_fallback(self, url1, url2):
         pb = download_cover(url1, size=185)
         if not pb:
             pb = download_cover(url2, size=185)
-        if pb:
-            GLib.idle_add(self.cover_img.set_from_pixbuf, pb)
-            GLib.idle_add(self.cover_lbl.set_markup,
-                          '<span foreground="#888888" size="small" letter_spacing="200">COVER</span>')
+        GLib.idle_add(self._show_cover_pixbuf, pb)
 
     def _load_cover(self, cover_url):
         pb = download_cover(cover_url, size=185)
-        if pb:
-            GLib.idle_add(self.cover_img.set_from_pixbuf, pb)
-            GLib.idle_add(self.cover_lbl.set_markup,
-                          '<span foreground="#888888" size="small" letter_spacing="200">COVER</span>')
+        GLib.idle_add(self._show_cover_pixbuf, pb)
 
     # ── Lancement streamrip ───────────────────────────────────────────────────
 
@@ -1673,12 +1727,10 @@ class AurynApp:
         self._log(line, tag)
 
     def _extract_meta_from_log(self, line):
+        # Log scraping only *fills* empty fields — it must never clobber the
+        # richer values already pulled from the API, hence overwrite=False.
         def sm(key, value):
-            if value:
-                txt = str(value).strip()[:30].replace("&","&amp;").replace("<","&lt;")
-                current = self._meta[key].get_text()
-                if current == "—" or not current:
-                    self._meta[key].set_markup(f'<span foreground="#e8e8e8" size="small">{txt}</span>')
+            self._set_meta(key, value, overwrite=False)
 
         m = re.search(r'^\s*Downloading\s+(.+?)\s*[─━—\-]{3,}\s*$', line)
         if m:
@@ -1709,7 +1761,7 @@ class AurynApp:
         if m:
             track_name = m.group(1).strip()
             self._set_status(f"🎵  {track_name[:80]}", "track")
-            artist = self._meta["Album Artist"].get_text()
+            artist = self._get_meta_text("Album Artist")
             if artist != "—" and artist:
                 threading.Thread(target=self._fetch_and_apply_lyrics, args=(artist, track_name), daemon=True).start()
 
@@ -1719,7 +1771,7 @@ class AurynApp:
         m = re.search(r'(?:UPC|Barcode)[:\s]+(\d{8,14})', line, re.I)
         if m: sm("UPC", m.group(1))
 
-        if self._meta["Album Quality"].get_text() in ("—", ""):
+        if self._get_meta_text("Album Quality") in ("—", ""):
             for pat in [
                 r'(FLAC\s+\d+\s*bit.{1,20}kHz)',
                 r'(\d+\s*bit\s*/\s*[\d.]+\s*kHz)',
@@ -1822,16 +1874,41 @@ class AurynApp:
         self.status_lbl.set_markup(build_status_markup(text, style))
 
     def _reset_meta(self):
+        # Tolerate any missing/renamed label so a UI refactor degrades the
+        # sidebar gracefully instead of crashing the whole reset path.
         for lbl in self._meta.values():
-            lbl.set_markup('<span foreground="#333333" size="small">—</span>')
+            if lbl is None:
+                continue
+            try:
+                lbl.set_markup('<span foreground="#333333" size="small">—</span>')
+            except Exception:
+                pass
         self._set_lyrics('<span foreground="#333333" size="small">—</span>')
         self._set_placeholder_cover()
-        self.speed_lbl.set_markup("")
+        self._set_cover_placeholder_label()
+        if self.speed_lbl is not None:
+            self.speed_lbl.set_markup("")
 
     def _set_placeholder_cover(self):
-        pb = GdkPixbuf.Pixbuf.new(GdkPixbuf.Colorspace.RGB, False, 8, 185, 185)
-        pb.fill(0x161616ff)
-        self.cover_img.set_from_pixbuf(pb)
+        """Show the neutral placeholder tile (startup, reset, cover failure)."""
+        if self.cover_img is None:
+            return
+        try:
+            pb = GdkPixbuf.Pixbuf.new(GdkPixbuf.Colorspace.RGB, False, 8, 185, 185)
+            pb.fill(0x161616ff)
+            self.cover_img.set_from_pixbuf(pb)
+        except Exception:
+            pass
+
+    def _set_cover_placeholder_label(self):
+        """Restore the dim 'COVER' caption used when no art is shown."""
+        if self.cover_lbl is None:
+            return
+        try:
+            self.cover_lbl.set_markup(
+                '<span foreground="#555555" size="small" letter_spacing="200">COVER</span>')
+        except Exception:
+            pass
 
     def _streamrip_config_path(self):
         # Mirrors streamrip's own click.get_app_dir("streamrip") resolution

--- a/src/core/metadata.py
+++ b/src/core/metadata.py
@@ -1,0 +1,131 @@
+"""Pure, GTK-free helpers for the right-side album metadata sidebar.
+
+The sidebar (cover art + artist / album / quality / track count / UPC /
+release date) is a protected, user-facing surface. The functions here own
+all the *parsing* and *text sanitising* logic so it can be unit-tested
+without GTK and so a malformed API payload can never crash the UI.
+
+Mirrors the existing isolated-helper pattern used by ``core.status`` and
+``core.errors``: dependency-free, side-effect-free, easy to test.
+
+Important: these functions must stay tolerant of partial / ``None`` /
+unexpectedly-shaped payloads. Streaming services occasionally return
+``{"artist": null}`` or omit fields entirely; that must degrade to an
+empty value, never an exception.
+"""
+
+import re
+
+# Default visual truncation length for a sidebar value. Kept identical to
+# the historical inline behaviour so the layout never shifts.
+META_MAX_LEN = 30
+
+# Color/markup for a populated metadata value (kept here so the one true
+# style lives in one place, like core.status.build_status_markup).
+_META_SPAN = '<span foreground="#e8e8e8" size="small">{}</span>'
+
+
+def sanitize_meta_text(value, limit=META_MAX_LEN):
+    """Return a Pango-safe, length-capped string for a metadata value.
+
+    Returns ``""`` for falsy / empty values so callers can simply skip
+    writing and leave the placeholder in place.
+    """
+    if not value:
+        return ""
+    txt = str(value).strip()
+    if not txt:
+        return ""
+    return txt[:limit].replace("&", "&amp;").replace("<", "&lt;")
+
+
+def build_meta_markup(value, limit=META_MAX_LEN):
+    """Return ready-to-use Pango markup for *value*, or ``None`` if empty."""
+    txt = sanitize_meta_text(value, limit)
+    if not txt:
+        return None
+    return _META_SPAN.format(txt)
+
+
+def _safe_dict(value):
+    """Return *value* if it is a dict, otherwise an empty dict.
+
+    Guards the very common ``data.get("artist", {}).get("name")`` idiom
+    against an explicit ``"artist": null`` (where ``.get`` returns ``None``
+    and the chained ``.get`` would raise ``AttributeError``).
+    """
+    return value if isinstance(value, dict) else {}
+
+
+def deezer_album_fields(data):
+    """Normalize a Deezer album payload into sidebar fields.
+
+    Always returns a dict with every expected key present (empty string
+    when unknown), regardless of how partial the input is.
+    """
+    data = _safe_dict(data)
+    artist = _safe_dict(data.get("artist")).get("name", "") or ""
+    return {
+        "artist": artist,
+        "album": data.get("title", "") or "",
+        "total_tracks": data.get("nb_tracks", "") or "",
+        "upc": data.get("upc", "") or "",
+        "release_date": data.get("release_date", "") or "",
+        # Deezer streams are reported as CD-quality FLAC by streamrip.
+        "quality": "FLAC 16-bit / 44.1 kHz",
+        "cover_url": (data.get("cover_xl")
+                      or data.get("cover_big")
+                      or data.get("cover_medium")
+                      or ""),
+    }
+
+
+def qobuz_album_fields(data):
+    """Normalize a Qobuz album payload into sidebar fields.
+
+    Reproduces the historical field selection (artist→performer fallback,
+    hi-res quality string, cover-size rewrite) but tolerates ``None`` /
+    missing sub-objects so a sparse payload cannot raise.
+    """
+    data = _safe_dict(data)
+
+    artist = (_safe_dict(data.get("artist")).get("name", "")
+              or _safe_dict(data.get("performer")).get("name", "")
+              or "")
+
+    tracks = data.get("tracks_count", _safe_dict(data.get("tracks")).get("total", ""))
+
+    raw_date = data.get("release_date_original") or data.get("released_at") or ""
+    if not isinstance(raw_date, str):
+        raw_date = str(raw_date)
+    release_date = raw_date[:10]
+
+    max_q = data.get("maximum_sampling_rate", 0)
+    max_b = data.get("maximum_bit_depth", 0)
+    if max_q and max_b:
+        quality = f"FLAC {max_b}-bit / {max_q} kHz"
+    elif data.get("hires_streamable"):
+        quality = "Hi-Res FLAC"
+    else:
+        quality = ""
+
+    img = _safe_dict(data.get("image"))
+    raw_cover = img.get("large") or img.get("small") or img.get("thumbnail", "") or ""
+    if raw_cover:
+        cover_url = re.sub(r'_\d+\.jpg', '_max.jpg', raw_cover)
+        cover_fallback = re.sub(r'_\d+\.jpg', '_600.jpg',
+                                cover_url.replace('_max.jpg', '_600.jpg'))
+    else:
+        cover_url = ""
+        cover_fallback = ""
+
+    return {
+        "artist": artist,
+        "album": data.get("title", "") or "",
+        "total_tracks": tracks or "",
+        "upc": data.get("upc", "") or "",
+        "release_date": release_date,
+        "quality": quality,
+        "cover_url": cover_url,
+        "cover_fallback": cover_fallback,
+    }

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,163 @@
+"""Regression tests for the protected album-metadata sidebar.
+
+These cover the GTK-free parsing/sanitising layer in ``core.metadata``
+that backs the right-side sidebar (cover + artist / album / quality /
+track count / UPC / release date). The guarantee under test: partial,
+``None``, or unexpectedly-shaped streaming-service payloads degrade to
+empty values and NEVER raise — so the UI cannot crash on bad metadata.
+"""
+
+from core import metadata
+
+
+# ── Text sanitising ──────────────────────────────────────────────────────
+
+def test_sanitize_empty_and_falsy_values_return_empty():
+    assert metadata.sanitize_meta_text("") == ""
+    assert metadata.sanitize_meta_text(None) == ""
+    assert metadata.sanitize_meta_text(0) == ""
+    assert metadata.sanitize_meta_text("   ") == ""
+
+
+def test_sanitize_strips_and_escapes_pango_markup():
+    assert metadata.sanitize_meta_text("  Hello  ") == "Hello"
+    assert metadata.sanitize_meta_text("A & B < C") == "A &amp; B &lt; C"
+
+
+def test_sanitize_truncates_to_limit():
+    assert metadata.sanitize_meta_text("x" * 50, limit=28) == "x" * 28
+    assert metadata.sanitize_meta_text("x" * 50) == "x" * metadata.META_MAX_LEN
+
+
+def test_build_meta_markup_wraps_or_returns_none():
+    assert metadata.build_meta_markup("") is None
+    assert metadata.build_meta_markup(None) is None
+    assert metadata.build_meta_markup("Foo") == (
+        '<span foreground="#e8e8e8" size="small">Foo</span>'
+    )
+
+
+def test_build_meta_markup_accepts_non_string_values():
+    # Track counts arrive as ints from the API.
+    assert metadata.build_meta_markup(14) == (
+        '<span foreground="#e8e8e8" size="small">14</span>'
+    )
+
+
+# ── Deezer payload normalisation ──────────────────────────────────────────
+
+def test_deezer_full_payload():
+    data = {
+        "artist": {"name": "Daft Punk"},
+        "title": "Discovery",
+        "nb_tracks": 14,
+        "upc": "724384960650",
+        "release_date": "2001-03-12",
+        "cover_xl": "xl.jpg",
+        "cover_big": "big.jpg",
+    }
+    f = metadata.deezer_album_fields(data)
+    assert f["artist"] == "Daft Punk"
+    assert f["album"] == "Discovery"
+    assert f["total_tracks"] == 14
+    assert f["upc"] == "724384960650"
+    assert f["release_date"] == "2001-03-12"
+    assert f["quality"] == "FLAC 16-bit / 44.1 kHz"
+    assert f["cover_url"] == "xl.jpg"
+
+
+def test_deezer_cover_precedence_falls_through_sizes():
+    f = metadata.deezer_album_fields({"cover_medium": "m.jpg"})
+    assert f["cover_url"] == "m.jpg"
+    assert metadata.deezer_album_fields({})["cover_url"] == ""
+
+
+def test_deezer_null_artist_does_not_raise():
+    # Deezer occasionally returns an explicit null sub-object; the old
+    # `data.get("artist", {}).get(...)` idiom would AttributeError here.
+    f = metadata.deezer_album_fields({"artist": None, "title": "X"})
+    assert f["artist"] == ""
+    assert f["album"] == "X"
+
+
+def test_deezer_handles_none_and_non_dict_input():
+    for bad in (None, [], "oops", 42):
+        f = metadata.deezer_album_fields(bad)
+        assert f["artist"] == ""
+        assert f["album"] == ""
+        assert f["cover_url"] == ""
+        # Constant quality string is always available for Deezer.
+        assert f["quality"] == "FLAC 16-bit / 44.1 kHz"
+
+
+# ── Qobuz payload normalisation ───────────────────────────────────────────
+
+def test_qobuz_full_payload_hires():
+    data = {
+        "artist": {"name": "Air"},
+        "title": "Moon Safari",
+        "tracks_count": 10,
+        "upc": "724384844820",
+        "release_date_original": "1998-01-16T00:00:00",
+        "maximum_sampling_rate": 96,
+        "maximum_bit_depth": 24,
+        "image": {"large": "https://cdn/x/cover_600.jpg"},
+    }
+    f = metadata.qobuz_album_fields(data)
+    assert f["artist"] == "Air"
+    assert f["album"] == "Moon Safari"
+    assert f["total_tracks"] == 10
+    assert f["release_date"] == "1998-01-16"
+    assert f["quality"] == "FLAC 24-bit / 96 kHz"
+    assert f["cover_url"] == "https://cdn/x/cover_max.jpg"
+    assert f["cover_fallback"] == "https://cdn/x/cover_600.jpg"
+
+
+def test_qobuz_artist_falls_back_to_performer():
+    f = metadata.qobuz_album_fields(
+        {"artist": None, "performer": {"name": "Performer X"}}
+    )
+    assert f["artist"] == "Performer X"
+
+
+def test_qobuz_quality_branches():
+    assert metadata.qobuz_album_fields(
+        {"hires_streamable": True})["quality"] == "Hi-Res FLAC"
+    # Neither sample-rate/bit-depth nor hires flag -> no quality (placeholder
+    # is kept by the caller because the value is empty).
+    assert metadata.qobuz_album_fields({})["quality"] == ""
+
+
+def test_qobuz_tracks_count_key_present_wins_over_tracks_object():
+    f = metadata.qobuz_album_fields(
+        {"tracks_count": 12, "tracks": {"total": 99}}
+    )
+    assert f["total_tracks"] == 12
+
+
+def test_qobuz_null_tracks_object_does_not_raise():
+    # Old `data.get("tracks", {}).get("total")` would AttributeError when
+    # the value is explicitly null.
+    f = metadata.qobuz_album_fields({"tracks": None})
+    assert f["total_tracks"] == ""
+
+
+def test_qobuz_null_image_does_not_raise():
+    f = metadata.qobuz_album_fields({"image": None})
+    assert f["cover_url"] == ""
+    assert f["cover_fallback"] == ""
+
+
+def test_qobuz_release_date_non_string_is_coerced():
+    f = metadata.qobuz_album_fields({"released_at": 1234567890})
+    assert f["release_date"] == "1234567890"[:10]
+
+
+def test_qobuz_handles_none_and_non_dict_input():
+    for bad in (None, [], "oops", 42):
+        f = metadata.qobuz_album_fields(bad)
+        assert f["artist"] == ""
+        assert f["album"] == ""
+        assert f["quality"] == ""
+        assert f["cover_url"] == ""
+        assert f["cover_fallback"] == ""


### PR DESCRIPTION
## Summary

The right-side album sidebar (cover art + artist / album / quality / track count / UPC / release date) is a critical UX surface. It previously crashed on partial API payloads (e.g. an explicit `"artist": null` from Deezer/Qobuz) and would break if a `.ui` widget id were renamed during a future refactor. This PR hardens it without redesigning the sidebar or touching download logic.

- **New `src/core/metadata.py`** — GTK-free, side-effect-free payload parsing/sanitising (mirrors the existing `core.status` / `core.errors` / `tidal_auth.scrub_secrets` isolated-helper pattern). Tolerates `None` / missing / non-dict input and reproduces the historical field selection, quality strings, and cover-size rewrite exactly for well-formed payloads.
- **Single hardened `_set_meta()` writer** — every sidebar text update (Deezer, Qobuz, and streamrip-log scraping) now routes through one helper. A missing/renamed widget or a broken GTK call becomes a safe no-op instead of taking down metadata parsing or the streamrip output pump. The `overwrite=False` mode preserves the log-scraping "don't clobber API values" behaviour.
- **Stable cover fallback** — when cover art is missing or fails to download, the sidebar keeps the existing neutral placeholder tile and caption rather than a blank slot. `_set_placeholder_cover` and the reset path are now exception-guarded.
- **Protected-surface note** — a short banner comment documents the rules for anyone editing this section.

Layout (`Auryn.ui`) and download logic are unchanged.

## Test plan

- [x] `python3 -m py_compile src/Auryn.py` passes
- [x] `pytest` — 17 GTK-free tests in `tests/test_metadata.py` pass (full payloads, `null` sub-objects, missing keys, non-dict input, cover precedence/rewrite, quality branches, Pango escaping/truncation)
- [x] Blocking `flake8 . --select=E9,F63,F7,F82` reports 0 errors
- [ ] Manual smoke: resolve a Deezer and a Qobuz album URL, confirm sidebar fields + cover populate as before; confirm a bad/unreachable cover URL leaves the placeholder stable

https://claude.ai/code/session_01AGva6vAWDu52rgqrJgnoBd

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGva6vAWDu52rgqrJgnoBd)_