### PR TITLE
Detect streamrip track errors instead of always reporting success

### DIFF
--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -26,6 +26,7 @@ from core.errors import parse_streamrip_error
 from core.status import build_status_markup
 from core import tidal_auth
 from core import metadata
+from core import streamrip_status
 
 APP_NAME = "Auryn"
 APP_VERSION = "0.1.1"
@@ -412,6 +413,10 @@ class AurynApp:
         self._tidal_auth_required   = False
         self._tidal_auth_corrupted  = False
         self._tb_noise_notified     = False
+        self._dl_error_count        = 0
+        self._dl_skip_count         = 0
+        self._dl_invalid_url        = False
+        self._dl_finished_marker    = False
         self._cfg_fingerprint_pre   = None
 
         # ── Forcer can-focus sur les widgets interactifs ──
@@ -591,6 +596,7 @@ class AurynApp:
         return {
             "Completed":   "#87a556",
             "Downloading": "#FF6B35",
+            "Warning":     "#e0a83b",
             "Failed":      "#e74c3c",
         }.get(status, "#aaaaaa")
 
@@ -716,7 +722,8 @@ class AurynApp:
 
         box.pack_start(left, True, True, 0)
 
-        if entry["status"] == "Completed":
+        if entry["status"] == "Completed" or (
+                entry["status"] == "Warning" and entry.get("folder")):
             btn = Gtk.Button(label="Open Folder")
             btn.get_style_context().add_class("neutral-btn")
             btn.set_valign(Gtk.Align.CENTER)
@@ -752,6 +759,7 @@ class AurynApp:
             "Queued":      "#888888",
             "Downloading": "#FF6B35",
             "Completed":   "#87a556",
+            "Warning":     "#e0a83b",
             "Failed":      "#e74c3c",
         }.get(status, "#aaaaaa")
 
@@ -920,6 +928,7 @@ class AurynApp:
         self._track_done       = 0
         self._total_tracks     = 0
         self._last_known_error = None
+        self._reset_streamrip_signals()
         self._set_status("⏳  Fetching album info...", "info")
         self._set_lyrics('<span foreground="#555555"><i>Lyrics appear here once a track is identified.</i></span>')
         quality = self._get_quality()
@@ -1666,6 +1675,10 @@ class AurynApp:
     def _parse_line(self, line):
         lo = line.lower()
 
+        # Tally success/error signals before any log-noise suppression so a
+        # collapsed traceback still counts toward the final outcome.
+        self._track_streamrip_signals(line)
+
         # TIDAL token_expiry crash: streamrip raises ValueError on
         # float(token_expiry) when it is empty/corrupt. Scoped to a TIDAL
         # download exactly like the auth-error detection below.
@@ -1783,26 +1796,107 @@ class AurynApp:
 
     # ── Fin ───────────────────────────────────────────────────────────────────
 
-    def _finish(self, success):
-        if success:
-            self._set_status("✅  Download complete!", "ok")
-            self.progress_bar.set_fraction(1.0)
-            self._log("\n✅  All downloads finished!\n", "ok")
-            folder = self._detect_new_folder(self._dest_folder, self._dest_dirs_snapshot) or self._dest_folder
-            self._history_set_status(self._current_history_entry, "Completed", folder=folder)
-            self._queue_set_status(self._current_queue_item, "Completed")
-        else:
-            code = self._process.returncode if self._process else -1
-            if code != -15:
-                status_msg = self._last_known_error or "❌  Download failed — check the log."
-                self._set_status(status_msg, "error")
-                self._log("\n❌  Download failed.\n", "error")
-            self._history_set_status(self._current_history_entry, "Failed")
-            self._queue_set_status(self._current_queue_item, "Failed")
+    def _reset_streamrip_signals(self):
+        """Clear the per-download success/error tallies."""
+        self._dl_error_count     = 0
+        self._dl_skip_count      = 0
+        self._dl_invalid_url     = False
+        self._dl_finished_marker = False
 
-        self._post_download_config_audit()
+    def _track_streamrip_signals(self, line):
+        """Accumulate streamrip success/error signals from one output line.
+
+        Runs before any log-noise suppression so a collapsed traceback is
+        still counted toward the final outcome.
+        """
+        if streamrip_status.line_says_finished(line):
+            self._dl_finished_marker = True
+        if streamrip_status.line_is_invalid_url(line):
+            self._dl_invalid_url = True
+            return
+        if streamrip_status.line_is_skip(line):
+            self._dl_skip_count += 1
+            return
+        if streamrip_status.line_is_error(line):
+            self._dl_error_count += 1
+
+    def _compute_download_outcome(self, success):
+        """Refine streamrip's exit code with the observed log signals."""
+        return streamrip_status.classify_outcome(
+            finished=self._dl_finished_marker,
+            error_count=self._dl_error_count,
+            skip_count=self._dl_skip_count,
+            invalid_url=self._dl_invalid_url,
+            process_ok=success,
+        )
+
+    def _streamrip_signal_summary(self):
+        """Short '(N track error(s), M skipped)' suffix, or '' if clean."""
+        parts = []
+        if self._dl_error_count:
+            parts.append(f"{self._dl_error_count} track "
+                         f"error{'s' if self._dl_error_count != 1 else ''}")
+        if self._dl_skip_count:
+            parts.append(f"{self._dl_skip_count} skipped")
+        return f" ({', '.join(parts)})" if parts else ""
+
+    def _finish_full_success(self):
+        self._set_status("✅  Download complete!", "ok")
+        self.progress_bar.set_fraction(1.0)
+        self._log("\n✅  All downloads finished!\n", "ok")
+        folder = self._detect_new_folder(self._dest_folder, self._dest_dirs_snapshot) or self._dest_folder
+        self._history_set_status(self._current_history_entry, "Completed", folder=folder)
+        self._queue_set_status(self._current_queue_item, "Completed")
+
+    def _finish_with_warnings(self):
+        self.progress_bar.set_fraction(1.0)
+        self._set_status(
+            "⚠  Download finished with errors — check the log.", "error")
+        self._log(
+            "\n⚠  Download finished with errors — check the log."
+            f"{self._streamrip_signal_summary()}\n", "error")
+        # Some tracks may still have landed; keep the folder link if one
+        # was created so partial results stay reachable.
+        folder = self._detect_new_folder(self._dest_folder, self._dest_dirs_snapshot)
+        self._history_set_status(self._current_history_entry, "Warning", folder=folder)
+        self._queue_set_status(self._current_queue_item, "Warning")
+
+    def _finish_invalid_url(self):
+        self._set_status(
+            "❌  streamrip rejected the URL — see the log.", "error")
+        self._log("\n❌  streamrip could not use this URL.\n", "error")
+        self._log(
+            "💡  Try opening the link in your browser and paste the "
+            "final service URL.\n", "info")
+        self._history_set_status(self._current_history_entry, "Failed")
+        self._queue_set_status(self._current_queue_item, "Failed")
+
+    def _finish_failed(self):
+        code = self._process.returncode if self._process else -1
+        if code != -15:
+            status_msg = self._last_known_error or "❌  Download failed — check the log."
+            self._set_status(status_msg, "error")
+            self._log("\n❌  Download failed.\n", "error")
+        self._history_set_status(self._current_history_entry, "Failed")
+        self._queue_set_status(self._current_queue_item, "Failed")
+
+    def _finish(self, success):
         user_stopped = (self._process is not None
                         and self._process.returncode == -15)
+        if user_stopped:
+            self._finish_failed()
+        else:
+            outcome = self._compute_download_outcome(success)
+            if outcome == streamrip_status.SUCCESS:
+                self._finish_full_success()
+            elif outcome == streamrip_status.PARTIAL:
+                self._finish_with_warnings()
+            elif outcome == streamrip_status.INVALID_URL:
+                self._finish_invalid_url()
+            else:
+                self._finish_failed()
+
+        self._post_download_config_audit()
         tidal_corrupted = (
             not success and self._tidal_auth_corrupted and not user_stopped)
         tidal_blocked = (

--- a/src/core/streamrip_status.py
+++ b/src/core/streamrip_status.py
@@ -1,0 +1,125 @@
+"""Classify streamrip CLI output into an honest download outcome.
+
+streamrip can exit ``0`` and still print ``All downloads finished!``
+even when individual tracks failed (for example
+``ERROR  Error downloading track: list index out of range``) or the
+pasted URL was rejected (``Found invalid url``). Reporting that as
+``Download complete!`` is misleading, so these helpers let the UI tell
+a clean run apart from a partial / failed / rejected one.
+
+Kept GTK-free and dependency-free so it can be unit-tested without
+importing the application module.
+"""
+
+import re
+
+# Per-track or fatal failure signatures.
+ERROR_PATTERNS = (
+    "error downloading track",
+    "traceback",
+    "download failed",
+    "unicodeencodeerror",
+    "valueerror",
+    "contenttypeerror",
+)
+
+# The URL itself was not usable (landing page / redirect / typo).
+INVALID_URL_PATTERNS = (
+    "found invalid url",
+    "invalid url",
+)
+
+# streamrip's end-of-run banner.
+FINISHED_MARKER = "all downloads finished"
+
+# Bare "ERROR" log-level token, e.g. streamrip prints "ERROR  ...".
+# Excludes streamrip's harmless "0 errors" run summary.
+_ERROR_TOKEN = re.compile(r"\berror\b")
+
+# Outcomes.
+SUCCESS = "success"          # finished cleanly, nothing errored/skipped
+PARTIAL = "partial"          # finished but some tracks errored/skipped
+FAILED = "failed"            # errors and no clean completion
+INVALID_URL = "invalid_url"  # streamrip rejected the URL outright
+
+
+def line_says_finished(line: str) -> bool:
+    """True if the line is streamrip's completion banner."""
+    return FINISHED_MARKER in line.lower()
+
+
+def line_is_invalid_url(line: str) -> bool:
+    """True if the line reports an invalid / unusable URL."""
+    lo = line.lower()
+    return any(p in lo for p in INVALID_URL_PATTERNS)
+
+
+def line_is_skip(line: str) -> bool:
+    """True if the line reports something being skipped."""
+    return "skipping" in line.lower()
+
+
+def line_is_error(line: str) -> bool:
+    """True if the line signals a track-level or fatal error."""
+    lo = line.lower()
+    if any(p in lo for p in ERROR_PATTERNS):
+        return True
+    # Bare "ERROR" log level, but not the benign "0 errors" summary.
+    return bool(_ERROR_TOKEN.search(lo)) and "0 errors" not in lo
+
+
+def classify_outcome(*, finished: bool, error_count: int, skip_count: int,
+                      invalid_url: bool, process_ok: bool) -> str:
+    """Derive an overall outcome from accumulated signals.
+
+    finished      streamrip printed its completion banner
+    error_count   number of error lines observed
+    skip_count    number of skip lines observed
+    invalid_url   an invalid / redirected URL was reported
+    process_ok    the streamrip process exited 0
+    """
+    if invalid_url and error_count == 0 and not finished:
+        return INVALID_URL
+    if finished or process_ok:
+        if error_count or skip_count or invalid_url:
+            return PARTIAL
+        return SUCCESS
+    return FAILED
+
+
+def summarize(lines, process_ok: bool) -> dict:
+    """Classify a string / iterable of output lines in one call.
+
+    Returns a dict with: ``outcome``, ``finished``, ``error_count``,
+    ``skip_count`` and ``invalid_url``. Convenience wrapper used by
+    tests and any caller that has the full output buffered.
+    """
+    if isinstance(lines, str):
+        lines = lines.splitlines()
+    errors = skips = 0
+    finished = invalid = False
+    for raw in lines:
+        s = raw.strip()
+        if not s:
+            continue
+        if line_says_finished(s):
+            finished = True
+        if line_is_invalid_url(s):
+            invalid = True
+            continue
+        if line_is_skip(s):
+            skips += 1
+            continue
+        if line_is_error(s):
+            errors += 1
+    outcome = classify_outcome(
+        finished=finished, error_count=errors, skip_count=skips,
+        invalid_url=invalid, process_ok=process_ok,
+    )
+    return {
+        "outcome": outcome,
+        "finished": finished,
+        "error_count": errors,
+        "skip_count": skips,
+        "invalid_url": invalid,
+    }

--- a/tests/test_streamrip_status.py
+++ b/tests/test_streamrip_status.py
@@ -1,0 +1,115 @@
+"""Tests for streamrip output classification.
+
+These guard the fix for the misleading "Download complete!" shown when
+streamrip exits 0 but the log contains track-level errors or a rejected
+URL (observed during Deezer testing). The classifier is GTK-free so it
+runs under plain ``pytest`` without importing the application module.
+"""
+
+from core import streamrip_status as s
+
+
+# ── Per-line predicates ───────────────────────────────────────────────────
+
+def test_line_says_finished_matches_banner():
+    assert s.line_says_finished("All downloads finished!")
+    assert s.line_says_finished("INFO  all downloads finished")
+    assert not s.line_says_finished("Downloading track 1")
+
+
+def test_line_is_error_catches_track_errors_and_tracebacks():
+    assert s.line_is_error(
+        "ERROR  Error downloading track: list index out of range")
+    assert s.line_is_error("Error downloading track")
+    assert s.line_is_error("Traceback (most recent call last):")
+    assert s.line_is_error("ValueError: bad value")
+    assert s.line_is_error("ContentTypeError: unexpected mimetype")
+    assert s.line_is_error("UnicodeEncodeError: 'charmap' codec")
+    assert s.line_is_error("Download failed")
+
+
+def test_line_is_error_ignores_benign_summary():
+    assert not s.line_is_error("Finished with 0 errors")
+    assert not s.line_is_error("Downloading track 'Intro'")
+
+
+def test_line_is_invalid_url_and_skip():
+    assert s.line_is_invalid_url("Found invalid url: https://deezer.com/x")
+    assert s.line_is_invalid_url("Invalid URL")
+    assert s.line_is_skip("Skipping track (already exists)")
+    assert not s.line_is_skip("Downloading track")
+
+
+# ── Aggregate outcomes ────────────────────────────────────────────────────
+
+def test_clean_run_is_success():
+    out = "\n".join([
+        "Downloading album 'Discovery'",
+        "Track Download Done",
+        "All downloads finished!",
+    ])
+    r = s.summarize(out, process_ok=True)
+    assert r["outcome"] == s.SUCCESS
+    assert r["finished"] is True
+    assert r["error_count"] == 0
+
+
+def test_finished_with_track_errors_is_partial():
+    out = "\n".join([
+        "Downloading album 'Discovery'",
+        "ERROR  Error downloading track: list index out of range",
+        "Error downloading track",
+        "All downloads finished!",
+    ])
+    r = s.summarize(out, process_ok=True)
+    assert r["outcome"] == s.PARTIAL
+    assert r["finished"] is True
+    assert r["error_count"] == 2
+
+
+def test_skips_without_errors_still_partial_when_finished():
+    out = "\n".join([
+        "Skipping track 1 (already exists)",
+        "All downloads finished!",
+    ])
+    r = s.summarize(out, process_ok=True)
+    assert r["outcome"] == s.PARTIAL
+    assert r["skip_count"] == 1
+    assert r["error_count"] == 0
+
+
+def test_invalid_url_without_finish_is_invalid_url():
+    r = s.summarize("Found invalid url: https://deezer.com/page",
+                     process_ok=False)
+    assert r["outcome"] == s.INVALID_URL
+    assert r["invalid_url"] is True
+
+
+def test_errors_without_finish_is_failed():
+    out = "\n".join([
+        "Error downloading track",
+        "Traceback (most recent call last):",
+    ])
+    r = s.summarize(out, process_ok=False)
+    assert r["outcome"] == s.FAILED
+    assert r["error_count"] >= 1
+
+
+def test_process_ok_with_no_finish_marker_but_clean_is_success():
+    r = s.summarize("Downloading album 'X'", process_ok=True)
+    assert r["outcome"] == s.SUCCESS
+
+
+def test_classify_outcome_direct_matrix():
+    assert s.classify_outcome(
+        finished=True, error_count=0, skip_count=0,
+        invalid_url=False, process_ok=True) == s.SUCCESS
+    assert s.classify_outcome(
+        finished=True, error_count=3, skip_count=0,
+        invalid_url=False, process_ok=True) == s.PARTIAL
+    assert s.classify_outcome(
+        finished=False, error_count=2, skip_count=0,
+        invalid_url=False, process_ok=False) == s.FAILED
+    assert s.classify_outcome(
+        finished=False, error_count=0, skip_count=0,
+        invalid_url=True, process_ok=False) == s.INVALID_URL


### PR DESCRIPTION
## Problem

During Deezer testing, streamrip resolved album metadata and cover art correctly but the log contained repeated track-level errors:

- `ERROR  Error downloading track: list index out of range`
- `Error downloading track`

while still ending with `All downloads finished!` and exiting `0`. Auryn treated that as a clean success and showed **"Download complete!"** — which is misleading.

## Change

- **New GTK-free classifier** `src/core/streamrip_status.py` — scans streamrip output for error / skip / invalid-URL signals and derives an honest outcome: `SUCCESS`, `PARTIAL`, `FAILED`, `INVALID_URL`. No new dependencies (stdlib `re` only).
- **Signal tracking** — `_parse_line()` now tallies signals via `_track_streamrip_signals()` *before* log-noise suppression, so a collapsed traceback still counts.
- **`_finish()` refactor** — dispatches to small per-outcome helpers instead of growing `_finish()`:
  - *Full success* → unchanged "Download complete!" / "All downloads finished!" / history **Completed**.
  - *Partial* (finished but errors/skips, or returncode 0 with no folder + errors) → "⚠ Download finished with errors — check the log." with a `(N track errors, M skipped)` summary; history/queue marked **Warning** (new amber status); folder link kept if partial files landed.
  - *Invalid / redirected URL* → no "Download complete!"; shows guidance: *"Try opening the link in your browser and paste the final service URL."*
  - *Failed* / user-stop → unchanged behaviour (including TIDAL auth dialogs).

## Out of scope (intentionally untouched)

- Download logic (subprocess / pty / Windows loops).
- Metadata / sidebar / cover art behaviour — right-side panel works exactly as-is.

## Tests

- New `tests/test_streamrip_status.py` covering per-line predicates and the aggregate outcome matrix (incl. the exact Deezer "finished with track errors" case).
- `python3 -m pytest tests/` → **28 passed** (no regressions).
- `python3 -m py_compile src/Auryn.py` → OK.

## Test plan

- [ ] Deezer download that errors per-track but prints "All downloads finished!" → shows warning, not "Download complete!", history shows **Warning**.
- [ ] Invalid / landing-page URL → shows browser-URL guidance, history **Failed**.
- [ ] Clean download → unchanged "Download complete!" / **Completed**.
- [ ] Stop button mid-download → unchanged stopped/Failed behaviour.
- [ ] TIDAL auth-required / corrupted run → auth dialog still appears.

https://claude.ai/code/session_01HRSDogWCkh7HYXubhU4LE7

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRSDogWCkh7HYXubhU4LE7)_