### PR TITLE
Make Deezer downloads reliable and diagnose streamrip failures

### DIFF
--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -28,6 +28,7 @@ from core import tidal_auth
 from core import metadata
 from core import streamrip_status
 from core import log_format
+from core import deezer
 
 APP_NAME = "Auryn"
 APP_VERSION = "0.1.1"
@@ -949,6 +950,10 @@ class AurynApp:
         self.btn_stop.set_sensitive(False)
 
     def _thread_main(self, url, quality):
+        if deezer.is_deezer_url(url):
+            url = self._prepare_deezer_url(url)
+            if url is None:
+                return  # pre-check failed; UI/queue already updated
         service, item_id = detect_service_and_id(url)
         if service == "qobuz" and item_id:
             GLib.idle_add(self._set_status, "⏳  Fetching metadata...", "info")
@@ -970,8 +975,107 @@ class AurynApp:
                 title = data.get("title")
                 if artist and title:
                     threading.Thread(target=self._fetch_and_apply_lyrics, args=(artist, title), daemon=True).start()
+        if deezer.is_deezer_url(url) and not self._deezer_config_ready():
+            return  # "Deezer not configured" — UI/queue already updated
         GLib.idle_add(self._set_status, "⏳  Preparing download...", "info")
         self._run_download(url, quality)
+
+    # ── Deezer pre-checks ──────────────────────────────────────────────────────
+    #
+    # streamrip only accepts a narrow set of Deezer URL forms and silently
+    # produces confusing per-track failures otherwise. These helpers normalize /
+    # resolve / validate the URL and confirm an ARL is configured BEFORE
+    # streamrip is spawned, so a bad link or missing credential fails fast with
+    # guidance instead of a mid-download crash. They run in the download worker
+    # thread; all UI work is marshalled back via GLib.idle_add.
+
+    def _prepare_deezer_url(self, url):
+        """Normalize / resolve / validate a Deezer URL before downloading.
+
+        Returns the URL to hand to streamrip, or None if the download was
+        aborted (UI + queue already updated by ``_finish_precheck_failed``).
+        """
+        info = deezer.classify_deezer_url(url)
+        normalized = info["normalized"]
+
+        if info["kind"] == deezer.SHORT_LINK:
+            GLib.idle_add(
+                self._log,
+                "🔗  Detected a Deezer share link — resolving to the full "
+                "deezer.com URL…\n", "info")
+            resolved, err = deezer.resolve_short_link(url)
+            if resolved:
+                GLib.idle_add(self._log, f"🔗  Resolved to: {resolved}\n", "info")
+                normalized = resolved
+                info = deezer.classify_deezer_url(resolved)
+            else:
+                detail = f" ({err})" if err else ""
+                GLib.idle_add(
+                    self._finish_precheck_failed,
+                    "❌  Could not resolve this Deezer share link.",
+                    [f"streamrip cannot open share links directly{detail}.",
+                     "💡  Open the link in your browser and paste the final "
+                     "deezer.com album / track / playlist URL instead."])
+                return None
+
+        if normalized != url:
+            GLib.idle_add(self._log,
+                          f"🔧  Using Deezer URL: {normalized}\n", "info")
+
+        if not deezer.streamrip_will_accept(normalized):
+            GLib.idle_add(
+                self._finish_precheck_failed,
+                "❌  Unsupported Deezer URL — see the log.",
+                ["streamrip only accepts deezer.com album / track / playlist / "
+                 "artist URLs (and deezer.page.link links).",
+                 "💡  Open the link in your browser and paste the final "
+                 "deezer.com URL."])
+            return None
+
+        return normalized
+
+    def _deezer_config_ready(self):
+        """True if streamrip is configured for Deezer; else abort with guidance.
+
+        Surfaces a clear "Deezer not configured" message before the download
+        instead of letting streamrip fail later. Never reads or logs the ARL.
+        """
+        st = deezer.deezer_config_status(self._streamrip_config_path())
+        if st["ready"]:
+            return True
+        guidance = ["Deezer downloads need an ARL cookie saved in streamrip's "
+                    "config.toml."]
+        guidance += [f"• {p}" for p in st["problems"]]
+        guidance.append("💡  Open Setup → Deezer, paste your ARL and Save, then "
+                        "try again.")
+        GLib.idle_add(
+            self._finish_precheck_failed,
+            "🔐  Deezer not configured — add your ARL in Setup.", guidance)
+        return False
+
+    def _finish_precheck_failed(self, status_msg, log_lines=None):
+        """Abort a download before streamrip is spawned; reset UI + queue.
+
+        Mirrors the tail of ``_finish`` (button reset, history/queue status,
+        queue advance) for failures detected during the pre-flight phase, when
+        there is no streamrip process to wait on. Runs on the GTK thread.
+        """
+        self._set_status(status_msg, "error")
+        self._log("\n" + status_msg + "\n", "error")
+        for line in (log_lines or []):
+            self._log(f"   {line}\n", "info")
+        self._history_set_status(self._current_history_entry, "Failed")
+        self._queue_set_status(self._current_queue_item, "Failed")
+        self._current_history_entry = None
+        self._current_queue_item = None
+        self.btn_download.set_sensitive(True)
+        self.btn_stop.hide()
+        self.speed_lbl.set_markup("")
+        if self._queue_stopped_by_user:
+            self._queue_stopped_by_user = False
+        else:
+            self._queue_start_next()
+        return False
 
     # ── Métadonnées ───────────────────────────────────────────────────────────
     #
@@ -1440,6 +1544,7 @@ class AurynApp:
         self._tidal_auth_required = False
         self._tidal_auth_corrupted = False
         self._tb_noise_notified = False
+        self._deezer_provider_notified = False
         self._cfg_fingerprint_pre = None
 
         if self.cb_clear_cache.get_active() and os.path.exists(db):
@@ -1478,9 +1583,25 @@ class AurynApp:
                 {"section": "qobuz", "key": "use_auth_token",
                  "value": "true", "quote": False},
             ]
+            # Deezer only supports quality 0..2; streamrip indexes a 3-row
+            # table with this value and crashes ("list index out of range")
+            # for anything higher. Clamp the value written to [deezer] so a
+            # FLAC-24/Max selection downgrades cleanly instead of failing
+            # every track. Other services keep the requested quality.
+            deezer_quality = deezer.clamp_quality(quality)
             for svc in ("qobuz", "tidal", "deezer", "soundcloud"):
+                svc_quality = deezer_quality if svc == "deezer" else quality
                 edits.append({"section": svc, "key": "quality",
-                              "value": str(quality), "quote": False})
+                              "value": str(svc_quality), "quote": False})
+
+            if deezer.is_deezer_url(url) and deezer.quality_was_clamped(quality):
+                GLib.idle_add(
+                    self._log,
+                    "ℹ️  Deezer supports up to quality "
+                    f"{deezer.DEEZER_MAX_QUALITY} "
+                    f"({deezer.quality_label(deezer.DEEZER_MAX_QUALITY)}); "
+                    f"using {deezer_quality} for this Deezer download "
+                    f"(requested {quality}).\n", "info")
 
             ok, err, changed = tidal_auth.apply_streamrip_config_updates(
                 cfg, edits)
@@ -1710,6 +1831,26 @@ class AurynApp:
             self._auth_log(
                 "🔐  Detected a TIDAL re-authentication / resync prompt in "
                 "streamrip output.\n", "error")
+
+        # Deezer-specific classification, scoped to a Deezer download so a
+        # Qobuz/TIDAL line never triggers it. The raw streamrip line is still
+        # logged below (raw details preserved); this only adds a clear,
+        # actionable one-liner. The provider-failure note is shown once so a
+        # per-track flood collapses to a single explanation.
+        if deezer.is_deezer_url(self._active_url):
+            cat, friendly = deezer.classify_deezer_error(line)
+            if cat == deezer.ERR_PROVIDER_FAILURE:
+                if not self._deezer_provider_notified:
+                    self._deezer_provider_notified = True
+                    self._set_status(deezer.PROVIDER_FAILURE_MESSAGE, "error")
+                    if not self._last_known_error:
+                        self._last_known_error = deezer.PROVIDER_FAILURE_MESSAGE
+                    self._log("⚠  " + deezer.PROVIDER_FAILURE_MESSAGE + "\n",
+                              "error")
+            elif cat and friendly:
+                self._set_status(friendly, "error")
+                if not self._last_known_error:
+                    self._last_known_error = friendly
 
         # Collapse raw traceback frames unless auth-debug is enabled so a
         # streamrip crash does not flood the log with internal frames.
@@ -3058,6 +3199,30 @@ class AurynApp:
                         'An ARL is already configured. Leave the field blank '
                         'to keep it.</span>'
                     ), False, False, 0)
+                deezer_row = Gtk.Box(
+                    orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+                deezer_row.set_halign(Gtk.Align.START)
+                test_deezer_btn = Gtk.Button(label="Test Deezer Setup")
+                test_deezer_btn.get_style_context().add_class("neutral-btn")
+
+                def on_test_deezer(_b):
+                    msg, kind = deezer.deezer_setup_summary(
+                        self._streamrip_config_path())
+                    if self._find_rip_path() is None:
+                        msg += "  Note: rip was not found in PATH."
+                        if kind == "ok":
+                            kind = "warn"
+                    set_status(msg, kind)
+
+                test_deezer_btn.connect("clicked", on_test_deezer)
+                deezer_row.pack_start(test_deezer_btn, False, False, 0)
+                body.pack_start(deezer_row, False, False, 0)
+                body.pack_start(note(
+                    '<span foreground="#666666" size="small">'
+                    'Test Deezer Setup checks your saved configuration only '
+                    '(ARL present, quality in range). It never downloads a '
+                    'full album or reveals your ARL.</span>'
+                ), False, False, 0)
                 state["entries"] = {"arl": arl_entry}
 
             else:  # tidal
@@ -3164,12 +3329,7 @@ class AurynApp:
                         msg, kind = ("Qobuz credentials are incomplete in "
                                      "config.toml. Save them first.", "warn")
                 elif service == "deezer":
-                    if saved.get("arl"):
-                        msg, kind = ("Deezer ARL is present in config.toml.",
-                                     "ok")
-                    else:
-                        msg, kind = ("No Deezer ARL found in config.toml. "
-                                     "Save it first.", "warn")
+                    msg, kind = deezer.deezer_setup_summary(cfg_path)
                 else:
                     msg, kind = self._tidal_connection_summary(cfg_path)
                 if not rip_ok:

--- a/src/core/deezer.py
+++ b/src/core/deezer.py
@@ -1,0 +1,467 @@
+"""Deezer support helpers for Auryn.
+
+Isolated, GTK-free, dependency-free logic that backs reliable Deezer
+downloads through streamrip:
+
+  * normalize & validate Deezer URLs exactly the way streamrip's URL parser
+    expects them, so an unsupported link fails fast with guidance instead of
+    a confusing mid-download crash,
+  * clamp the requested download quality to Deezer's supported range — the
+    root-cause fix for streamrip's repeated
+    ``Error downloading track: list index out of range`` (streamrip indexes a
+    three-row quality table with the configured quality, so any value above 2
+    raises ``IndexError`` on *every* track),
+  * inspect the streamrip-managed ``[deezer]`` config (ARL presence) without
+    ever returning, logging or rendering the ARL,
+  * classify Deezer-specific streamrip output into actionable categories.
+
+Security invariant: no function in this module ever returns, logs, renders or
+otherwise surfaces a raw ARL / session token. ARL state is reported only as
+"present / missing".
+
+Has no GTK / Auryn imports on purpose so it can be exercised by ``--doctor``
+and unit tests without a display. Mirrors the isolated-helper pattern of
+``core.tidal_auth``, ``core.metadata`` and ``core.streamrip_status``.
+"""
+
+import os
+import re
+import urllib.request
+
+# streamrip's ``DeezerClient.max_quality`` (streamrip/client/deezer.py). The
+# quality table there has exactly three rows — 0 = MP3 128, 1 = MP3 320,
+# 2 = FLAC (CD quality) — and ``get_downloadable`` does ``quality_map[quality]``
+# with no bounds check, so a configured quality of 3 or 4 raises
+# ``IndexError: list index out of range`` for every track.
+DEEZER_MAX_QUALITY = 2
+
+# Stable, user-facing message for the streamrip provider crash. Defined once so
+# the UI and the tests share a single wording.
+PROVIDER_FAILURE_MESSAGE = (
+    "Deezer provider failed while resolving/downloading tracks. "
+    "Try another Deezer URL format or update streamrip."
+)
+
+# URL classification kinds returned by :func:`classify_deezer_url`.
+NOT_DEEZER = "not_deezer"      # not a Deezer URL at all
+CONTENT = "content"            # canonical album/track/playlist/artist URL
+PAGE_LINK = "page_link"        # deezer.page.link (streamrip resolves natively)
+SHORT_LINK = "short_link"      # link.deezer.com / dzr.page.link (must resolve)
+UNSUPPORTED = "unsupported"    # a deezer.com URL streamrip will not accept
+
+# Error categories returned by :func:`classify_deezer_error`.
+ERR_AUTH_MISSING = "auth_missing"
+ERR_AUTH_INVALID = "auth_invalid"
+ERR_UNSUPPORTED_URL = "unsupported_url"
+ERR_PROVIDER_FAILURE = "provider_failure"
+ERR_RATE_LIMIT = "rate_limit"
+ERR_TRACK_FAILURE = "track_failure"
+
+
+# Any Deezer-family host. Deliberately broad: it only gates whether
+# Deezer-specific handling applies; the strict acceptance check is
+# :func:`streamrip_will_accept`.
+_DEEZER_HOST_RE = re.compile(
+    r"(?:^|//|\.)(?:deezer\.com|deezer\.page\.link|link\.deezer\.com|"
+    r"dzr\.page\.link)\b",
+    re.I,
+)
+
+# A canonical Deezer content URL → captures (media_type, item_id). Tolerates
+# any subdomain, an optional two-letter locale segment, and a trailing query
+# string / fragment.
+_CONTENT_RE = re.compile(
+    r"https?://(?:[a-z0-9-]+\.)?deezer\.com/(?:[a-z]{2}/)?"
+    r"(album|artist|track|playlist)/(\d+)",
+    re.I,
+)
+
+# streamrip's own native dynamic-link form (handled inside streamrip).
+_PAGE_LINK_RE = re.compile(r"https?://deezer\.page\.link/\w+", re.I)
+
+# Short / share links streamrip does NOT understand and that must be resolved
+# to a canonical content URL before download.
+_SHORT_LINK_RE = re.compile(
+    r"https?://(?:link\.deezer\.com|dzr\.page\.link)/\S+", re.I
+)
+
+# Faithful mirror of streamrip's ``GenericURL.URL_REGEX`` (streamrip/rip/
+# parse_url.py), used to validate that a final URL is one streamrip will
+# actually accept. Group 1 = source, 2 = media_type, 3 = item_id — streamrip
+# rejects the URL unless all three are present. Kept in sync with the installed
+# streamrip; if streamrip later widens support the worst case is we fall back
+# to its own "invalid url" handling, which Auryn already classifies.
+_STREAMRIP_GENERIC_RE = re.compile(
+    r"https?://(?:www|open|play|listen)?\.?(qobuz|tidal|deezer)\.com"
+    r"(?:(?:/(album|artist|track|playlist|video|label))|(?:/[-\w]+?))+/([-\w]+)",
+)
+
+_SCHEME_RE = re.compile(r"[a-z][a-z0-9+.-]*://", re.I)
+_BARE_HOST_RE = re.compile(
+    r"(?:[a-z0-9-]+\.)?(?:deezer\.com|deezer\.page\.link|link\.deezer\.com|"
+    r"dzr\.page\.link)/",
+    re.I,
+)
+
+
+# ── Quality ────────────────────────────────────────────────────────────────
+
+def clamp_quality(quality):
+    """Clamp *quality* into Deezer's supported 0..2 range.
+
+    Accepts ints or numeric strings; anything unparseable falls back to the
+    maximum supported quality. This is the fix that prevents streamrip's
+    ``list index out of range`` crash on Deezer.
+    """
+    try:
+        q = int(str(quality).strip())
+    except (TypeError, ValueError):
+        return DEEZER_MAX_QUALITY
+    if q < 0:
+        return 0
+    if q > DEEZER_MAX_QUALITY:
+        return DEEZER_MAX_QUALITY
+    return q
+
+
+def quality_was_clamped(quality):
+    """True if :func:`clamp_quality` would change *quality*."""
+    try:
+        return int(str(quality).strip()) != clamp_quality(quality)
+    except (TypeError, ValueError):
+        return True
+
+
+def quality_label(quality):
+    """Human label for a Deezer quality level."""
+    return {
+        0: "MP3 128 kbps",
+        1: "MP3 320 kbps",
+        2: "FLAC (CD quality)",
+    }.get(quality, str(quality))
+
+
+# ── URL handling ─────────────────────────────────────────────────────────────
+
+def is_deezer_url(url):
+    """True if *url* points at any Deezer-family host."""
+    return bool(url) and bool(_DEEZER_HOST_RE.search(url))
+
+
+def is_short_link(url):
+    """True for a Deezer share link streamrip cannot open directly."""
+    return bool(url) and bool(_SHORT_LINK_RE.match(url.strip()))
+
+
+def _canonical_content_url(media_type, item_id):
+    return "https://www.deezer.com/{}/{}".format(str(media_type).lower(),
+                                                 item_id)
+
+
+def normalize_deezer_url(url):
+    """Pure (no-network) normalization of a pasted Deezer URL.
+
+    * adds a missing ``https://`` scheme for a recognised Deezer host,
+    * canonicalises a content URL to ``https://www.deezer.com/<type>/<id>``
+      (dropping locale prefixes and tracking query strings) — a form both
+      streamrip's parser and Auryn's metadata sidebar accept.
+
+    Anything that is not a recognisable Deezer *content* URL (short links,
+    page.link, non-Deezer) is returned with only the scheme fixed so the
+    caller can resolve / validate it next. Never raises.
+    """
+    u = (url or "").strip()
+    if not u:
+        return u
+    if not _SCHEME_RE.match(u) and _BARE_HOST_RE.match(u):
+        u = "https://" + u
+    m = _CONTENT_RE.search(u)
+    if m:
+        return _canonical_content_url(m.group(1), m.group(2))
+    return u
+
+
+def streamrip_will_accept(url):
+    """True if streamrip's URL parser will accept *url* as a Deezer URL.
+
+    Mirrors streamrip's ``GenericURL`` (all of source/media_type/item_id must
+    be present) and its ``deezer.page.link`` dynamic-link matcher.
+    """
+    u = (url or "").strip()
+    m = _STREAMRIP_GENERIC_RE.match(u)
+    if m and all(m.group(i) for i in (1, 2, 3)) and m.group(1).lower() == "deezer":
+        return True
+    return bool(_PAGE_LINK_RE.match(u))
+
+
+def classify_deezer_url(url):
+    """Classify *url* for the download pre-check.
+
+    Returns a dict with: ``kind`` (one of the module constants),
+    ``media_type``, ``item_id``, ``normalized``, ``supported`` (streamrip will
+    accept it as-is) and ``needs_resolution`` (a short link to resolve first).
+    Pure / no network.
+    """
+    raw = (url or "").strip()
+    result = {
+        "kind": NOT_DEEZER,
+        "media_type": None,
+        "item_id": None,
+        "normalized": raw,
+        "supported": False,
+        "needs_resolution": False,
+    }
+    if not is_deezer_url(raw):
+        return result
+
+    normalized = normalize_deezer_url(raw)
+    result["normalized"] = normalized
+
+    m = _CONTENT_RE.search(normalized)
+    if m:
+        result.update(kind=CONTENT, media_type=m.group(1).lower(),
+                      item_id=m.group(2), supported=True)
+        return result
+    if _PAGE_LINK_RE.match(normalized):
+        result.update(kind=PAGE_LINK, supported=True)
+        return result
+    if _SHORT_LINK_RE.match(normalized):
+        result.update(kind=SHORT_LINK, needs_resolution=True)
+        return result
+    result.update(kind=UNSUPPORTED, supported=streamrip_will_accept(normalized))
+    return result
+
+
+def _default_opener(target, timeout):
+    req = urllib.request.Request(target, headers={"User-Agent": "Mozilla/5.0"})
+    return urllib.request.urlopen(req, timeout=timeout)
+
+
+def resolve_short_link(url, opener=None, timeout=8, max_bytes=200000):
+    """Follow a Deezer share link to its canonical content URL.
+
+    Returns ``(resolved_url_or_None, error_or_None)``. Network access goes
+    through *opener* (injectable for tests); the default uses ``urllib`` with a
+    browser User-Agent. This only follows the public redirect and, failing
+    that, scans the public landing page for a deezer.com content URL — the same
+    technique streamrip itself uses for ``deezer.page.link``. No authentication,
+    no protected-content scraping and no DRM handling is involved. Never raises.
+    """
+    target = normalize_deezer_url(url)
+    opener = opener or (lambda u: _default_opener(u, timeout))
+
+    resp = None
+    try:
+        resp = opener(target)
+    except Exception:
+        return (None, "the share link could not be opened (network error)")
+
+    try:
+        final_url = ""
+        try:
+            final_url = resp.geturl() or ""
+        except Exception:
+            final_url = ""
+        m = _CONTENT_RE.search(final_url)
+        if m:
+            return (normalize_deezer_url(final_url), None)
+
+        body = ""
+        try:
+            raw = resp.read(max_bytes)
+            body = (raw.decode("utf-8", "replace")
+                    if isinstance(raw, (bytes, bytearray)) else str(raw))
+        except Exception:
+            body = ""
+        m = _CONTENT_RE.search(body)
+        if m:
+            return (_canonical_content_url(m.group(1), m.group(2)), None)
+        return (None,
+                "the link did not resolve to a Deezer album/track/playlist URL")
+    finally:
+        try:
+            resp.close()
+        except Exception:
+            pass
+
+
+# ── Config detection ─────────────────────────────────────────────────────────
+
+def read_deezer_section(cfg_path):
+    """Best-effort read of the ``[deezer]`` table from ``config.toml``.
+
+    Returns ``{key: value}`` (native types from tomllib, else strings) or
+    ``{}`` on any problem. Never raises and never logs the values it reads.
+    """
+    try:
+        with open(cfg_path, "r", encoding="utf-8") as f:
+            text = f.read()
+    except OSError:
+        return {}
+    try:
+        import tomllib  # stdlib on Python 3.11+
+
+        sec = tomllib.loads(text).get("deezer")
+        if isinstance(sec, dict):
+            return dict(sec)
+    except Exception:
+        pass
+    result = {}
+    in_section = False
+    for line in text.split("\n"):
+        s = line.strip()
+        m = re.match(r"\[([^\]]+)\]\s*$", s)
+        if m:
+            in_section = m.group(1).strip() == "deezer"
+            continue
+        if in_section:
+            km = re.match(r'([A-Za-z0-9_]+)\s*=\s*"?(.*?)"?\s*$', s)
+            if km:
+                result[km.group(1)] = km.group(2)
+    return result
+
+
+def _as_bool(value):
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return None
+    return str(value).strip().lower() in ("true", "1", "yes", "on")
+
+
+def deezer_config_status(cfg_path):
+    """Return a structured, secret-free view of Deezer config readiness.
+
+    Keys: ``config_exists``, ``section_readable``, ``arl_present``,
+    ``quality`` (int or None), ``quality_in_range``, ``use_deezloader``
+    (bool or None), ``problems`` (list of human strings) and ``ready``
+    (True when streamrip has what it needs to authenticate Deezer).
+    The ARL value itself is never returned.
+    """
+    status = {
+        "config_exists": os.path.exists(cfg_path),
+        "section_readable": False,
+        "arl_present": False,
+        "quality": None,
+        "quality_in_range": True,
+        "use_deezloader": None,
+        "problems": [],
+        "ready": False,
+    }
+    if not status["config_exists"]:
+        status["problems"].append("streamrip config.toml not found.")
+        return status
+
+    sec = read_deezer_section(cfg_path)
+    if not sec:
+        status["problems"].append(
+            "Could not read the [deezer] section from config.toml "
+            "(missing or unparseable).")
+        return status
+    status["section_readable"] = True
+
+    arl = sec.get("arl")
+    status["arl_present"] = bool(arl is not None and str(arl).strip())
+
+    raw_q = sec.get("quality")
+    if raw_q is not None and str(raw_q).strip() != "":
+        try:
+            status["quality"] = int(str(raw_q).strip().strip('"'))
+        except ValueError:
+            status["quality"] = None
+    if status["quality"] is not None:
+        status["quality_in_range"] = 0 <= status["quality"] <= DEEZER_MAX_QUALITY
+
+    status["use_deezloader"] = _as_bool(sec.get("use_deezloader"))
+
+    if not status["arl_present"]:
+        status["problems"].append(
+            "No Deezer ARL is configured. streamrip needs an ARL cookie to "
+            "authenticate Deezer downloads.")
+
+    status["ready"] = status["arl_present"]
+    return status
+
+
+def deezer_setup_summary(cfg_path):
+    """Offline, secret-free readiness check → ``(message, kind)``.
+
+    Inspects only the saved config (no network, no download) and reports
+    whether streamrip is configured for Deezer, never showing the ARL. Mirrors
+    the offline ``Test TIDAL Connection`` behaviour. ``kind`` is one of
+    ``ok`` / ``warn`` / ``info``.
+    """
+    st = deezer_config_status(cfg_path)
+    if not st["config_exists"]:
+        return ("streamrip config.toml not found — run `rip config reset` or "
+                "open Setup first.", "warn")
+    if not st["section_readable"]:
+        return ("The [deezer] section is missing or unreadable in "
+                "config.toml.", "warn")
+    if not st["arl_present"]:
+        return ("Deezer is not configured — no ARL found. Paste your ARL above "
+                "and Save.", "warn")
+
+    parts = ["ARL is configured (value hidden)"]
+    if st["quality"] is not None:
+        if st["quality_in_range"]:
+            parts.append("quality {} ({})".format(
+                st["quality"], quality_label(st["quality"])))
+        else:
+            parts.append("saved quality {} is out of range — Auryn will use {} "
+                         "({}) for Deezer".format(
+                             st["quality"], DEEZER_MAX_QUALITY,
+                             quality_label(DEEZER_MAX_QUALITY)))
+    return ("Deezer looks ready — " + ", ".join(parts) + ".", "ok")
+
+
+# ── Error classification ───────────────────────────────────────────────────
+
+def classify_deezer_error(text):
+    """Classify a Deezer-related streamrip output line.
+
+    Returns ``(category, friendly_message_or_None)``; ``(None, None)`` when the
+    line is not a recognised Deezer error. Callers should scope this to a Deezer
+    download (``is_deezer_url``) so a Qobuz/TIDAL line never triggers it, just
+    like the TIDAL detectors in :mod:`core.tidal_auth`.
+    """
+    if not text:
+        return (None, None)
+    lo = text.lower()
+
+    # The streamrip provider crash — check first because the same line also
+    # contains "error downloading track".
+    if "list index out of range" in lo:
+        return (ERR_PROVIDER_FAILURE, PROVIDER_FAILURE_MESSAGE)
+
+    if ("missingcredentialserror" in lo or "missing credentials" in lo
+            or ("arl" in lo and any(p in lo for p in (
+                "empty", "missing", "not set", "no arl", "required")))):
+        return (ERR_AUTH_MISSING,
+                "Deezer is not configured — add your ARL in Setup.")
+
+    if (any(p in lo for p in ("invalid arl", "arl expired", "arl is invalid",
+                              "bad arl", "wrong arl"))
+            or ("deezer" in lo and "authenticationerror" in lo)
+            or ("arl" in lo and "invalid" in lo)):
+        return (ERR_AUTH_INVALID,
+                "Deezer ARL is invalid or expired — update it in Setup.")
+
+    if ("found invalid url" in lo or "invalid url" in lo
+            or "unable to extract deezer dynamic link" in lo):
+        return (ERR_UNSUPPORTED_URL,
+                "Unsupported Deezer URL — paste a deezer.com album, track or "
+                "playlist link.")
+
+    if any(p in lo for p in ("connectionpool", "api.deezer.com",
+                             "too many requests", "max retries",
+                             "connection aborted", "connection reset",
+                             "rate limit", "ratelimit", " 429")):
+        return (ERR_RATE_LIMIT,
+                "Deezer API rate-limit or network issue — wait a moment and "
+                "retry.")
+
+    if "error downloading track" in lo:
+        return (ERR_TRACK_FAILURE, None)
+
+    return (None, None)

--- a/tests/test_deezer.py
+++ b/tests/test_deezer.py
@@ -1,0 +1,296 @@
+"""Tests for the GTK-free Deezer support layer (``core.deezer``).
+
+These guard the fixes for the Deezer download failures observed during
+testing — chiefly the repeated
+``ERROR  Error downloading track: list index out of range``, whose root cause
+is a configured quality above Deezer's supported maximum (streamrip indexes a
+three-row quality table). They also cover URL normalization / validation,
+secret-free config detection and error classification.
+
+The module is GTK-free so these run under plain ``pytest`` without importing
+the application module.
+"""
+
+import os
+import textwrap
+
+from core import deezer as d
+
+
+# ── Quality clamping (the root-cause fix) ──────────────────────────────────
+
+def test_clamp_quality_passes_supported_values():
+    assert d.clamp_quality(0) == 0
+    assert d.clamp_quality(1) == 1
+    assert d.clamp_quality(2) == 2
+
+
+def test_clamp_quality_lowers_out_of_range_values():
+    # 3 (FLAC 24/96+) and 4 (Max/MQA) are exactly what crashed streamrip.
+    assert d.clamp_quality(3) == d.DEEZER_MAX_QUALITY == 2
+    assert d.clamp_quality(4) == 2
+
+
+def test_clamp_quality_handles_strings_and_garbage():
+    assert d.clamp_quality("3") == 2
+    assert d.clamp_quality("2") == 2
+    assert d.clamp_quality(-1) == 0
+    assert d.clamp_quality(None) == 2
+    assert d.clamp_quality("nonsense") == 2
+
+
+def test_quality_was_clamped():
+    assert d.quality_was_clamped(3) is True
+    assert d.quality_was_clamped(4) is True
+    assert d.quality_was_clamped(2) is False
+    assert d.quality_was_clamped(0) is False
+
+
+# ── URL detection / normalization ───────────────────────────────────────────
+
+def test_is_deezer_url():
+    assert d.is_deezer_url("https://www.deezer.com/album/123")
+    assert d.is_deezer_url("https://deezer.page.link/abc")
+    assert d.is_deezer_url("https://link.deezer.com/s/abc")
+    assert not d.is_deezer_url("https://tidal.com/album/123")
+    assert not d.is_deezer_url("https://notdeezer.example.com/x")
+    assert not d.is_deezer_url("")
+
+
+def test_normalize_adds_scheme():
+    assert d.normalize_deezer_url("www.deezer.com/album/123") == (
+        "https://www.deezer.com/album/123")
+    assert d.normalize_deezer_url("deezer.com/track/9").startswith("https://")
+
+
+def test_normalize_canonicalises_locale_and_query():
+    assert d.normalize_deezer_url(
+        "https://www.deezer.com/en/album/302127?utm_source=share"
+    ) == "https://www.deezer.com/album/302127"
+    assert d.normalize_deezer_url(
+        "https://deezer.com/fr/track/3135556"
+    ) == "https://www.deezer.com/track/3135556"
+
+
+def test_normalize_leaves_short_and_page_links_alone_except_scheme():
+    assert d.normalize_deezer_url("https://deezer.page.link/xyz") == (
+        "https://deezer.page.link/xyz")
+    assert d.normalize_deezer_url("link.deezer.com/s/abc") == (
+        "https://link.deezer.com/s/abc")
+
+
+# ── streamrip acceptance contract ───────────────────────────────────────────
+
+def test_streamrip_will_accept_matches_supported_forms():
+    assert d.streamrip_will_accept("https://www.deezer.com/album/302127")
+    assert d.streamrip_will_accept("https://www.deezer.com/en/track/3135556")
+    assert d.streamrip_will_accept("https://deezer.com/playlist/12")
+    assert d.streamrip_will_accept("https://deezer.page.link/abcDEF")
+
+
+def test_streamrip_will_not_accept_unsupported_forms():
+    # streamrip's dynamic-link matcher only knows deezer.page.link.
+    assert not d.streamrip_will_accept("https://link.deezer.com/s/abc123")
+    assert not d.streamrip_will_accept("https://dzr.page.link/abc123")
+    # No media type / id.
+    assert not d.streamrip_will_accept("https://www.deezer.com/profile/me")
+    assert not d.streamrip_will_accept("not a url")
+
+
+# ── URL classification ───────────────────────────────────────────────────────
+
+def test_classify_content_url():
+    info = d.classify_deezer_url("https://www.deezer.com/en/album/302127")
+    assert info["kind"] == d.CONTENT
+    assert info["media_type"] == "album"
+    assert info["item_id"] == "302127"
+    assert info["normalized"] == "https://www.deezer.com/album/302127"
+    assert info["supported"] is True
+    assert info["needs_resolution"] is False
+
+
+def test_classify_page_link_is_supported_native():
+    info = d.classify_deezer_url("https://deezer.page.link/abc")
+    assert info["kind"] == d.PAGE_LINK
+    assert info["supported"] is True
+    assert info["needs_resolution"] is False
+
+
+def test_classify_short_link_needs_resolution():
+    for url in ("https://link.deezer.com/s/abc123",
+                "https://dzr.page.link/xyz"):
+        info = d.classify_deezer_url(url)
+        assert info["kind"] == d.SHORT_LINK
+        assert info["needs_resolution"] is True
+        assert info["supported"] is False
+
+
+def test_classify_non_deezer():
+    info = d.classify_deezer_url("https://tidal.com/album/1")
+    assert info["kind"] == d.NOT_DEEZER
+
+
+# ── Short-link resolution (injected opener, no network) ──────────────────────
+
+class _FakeResp:
+    def __init__(self, final_url="", body=""):
+        self._final = final_url
+        self._body = body.encode("utf-8")
+
+    def geturl(self):
+        return self._final
+
+    def read(self, *_):
+        return self._body
+
+    def close(self):
+        pass
+
+
+def test_resolve_short_link_via_final_url():
+    resolved, err = d.resolve_short_link(
+        "https://link.deezer.com/s/abc",
+        opener=lambda u: _FakeResp(
+            final_url="https://www.deezer.com/en/album/302127"))
+    assert err is None
+    assert resolved == "https://www.deezer.com/album/302127"
+
+
+def test_resolve_short_link_via_body_scan():
+    html = '<a href="https://www.deezer.com/fr/track/3135556">x</a>'
+    resolved, err = d.resolve_short_link(
+        "https://link.deezer.com/s/abc",
+        opener=lambda u: _FakeResp(final_url="https://link.deezer.com/landing",
+                                   body=html))
+    assert err is None
+    assert resolved == "https://www.deezer.com/track/3135556"
+
+
+def test_resolve_short_link_failure_returns_error():
+    resolved, err = d.resolve_short_link(
+        "https://link.deezer.com/s/abc",
+        opener=lambda u: _FakeResp(final_url="https://example.com/nope",
+                                   body="no deezer link here"))
+    assert resolved is None
+    assert err
+
+
+def test_resolve_short_link_network_error_is_caught():
+    def boom(_u):
+        raise OSError("network down")
+
+    resolved, err = d.resolve_short_link("https://link.deezer.com/s/abc",
+                                         opener=boom)
+    assert resolved is None
+    assert err
+
+
+# ── Config detection (never leaks the ARL) ──────────────────────────────────
+
+def _write_cfg(tmp_path, body):
+    p = tmp_path / "config.toml"
+    p.write_text(textwrap.dedent(body), encoding="utf-8")
+    return str(p)
+
+
+def test_config_status_missing_file(tmp_path):
+    st = d.deezer_config_status(str(tmp_path / "nope.toml"))
+    assert st["config_exists"] is False
+    assert st["ready"] is False
+    assert st["problems"]
+
+
+def test_config_status_no_arl(tmp_path):
+    cfg = _write_cfg(tmp_path, '''
+        [deezer]
+        arl = ""
+        quality = 2
+    ''')
+    st = d.deezer_config_status(cfg)
+    assert st["section_readable"] is True
+    assert st["arl_present"] is False
+    assert st["ready"] is False
+
+
+def test_config_status_with_arl_and_quality(tmp_path):
+    cfg = _write_cfg(tmp_path, '''
+        [deezer]
+        arl = "SECRET_ARL_VALUE"
+        quality = 2
+        use_deezloader = true
+    ''')
+    st = d.deezer_config_status(cfg)
+    assert st["arl_present"] is True
+    assert st["ready"] is True
+    assert st["quality"] == 2
+    assert st["quality_in_range"] is True
+    assert st["use_deezloader"] is True
+    # The ARL value must never appear anywhere in the returned structure.
+    assert "SECRET_ARL_VALUE" not in repr(st)
+
+
+def test_config_status_flags_out_of_range_quality(tmp_path):
+    cfg = _write_cfg(tmp_path, '''
+        [deezer]
+        arl = "x"
+        quality = 4
+    ''')
+    st = d.deezer_config_status(cfg)
+    assert st["quality"] == 4
+    assert st["quality_in_range"] is False
+
+
+def test_setup_summary_messages(tmp_path):
+    missing = d.deezer_setup_summary(str(tmp_path / "no.toml"))
+    assert missing[1] == "warn"
+
+    cfg_no_arl = _write_cfg(tmp_path, '[deezer]\narl = ""\nquality = 2\n')
+    msg, kind = d.deezer_setup_summary(cfg_no_arl)
+    assert kind == "warn"
+    assert "not configured" in msg.lower()
+
+    cfg_ok = _write_cfg(tmp_path, '[deezer]\narl = "tok"\nquality = 2\n')
+    msg, kind = d.deezer_setup_summary(cfg_ok)
+    assert kind == "ok"
+    assert "tok" not in msg  # never echo the ARL
+
+
+# ── Error classification ───────────────────────────────────────────────────
+
+def test_classify_list_index_is_provider_failure():
+    cat, msg = d.classify_deezer_error(
+        "ERROR  Error downloading track: list index out of range")
+    assert cat == d.ERR_PROVIDER_FAILURE
+    assert msg == d.PROVIDER_FAILURE_MESSAGE
+
+
+def test_classify_auth_missing_and_invalid():
+    cat, _ = d.classify_deezer_error("raise MissingCredentialsError")
+    assert cat == d.ERR_AUTH_MISSING
+    cat, _ = d.classify_deezer_error("Invalid arl, try again.")
+    assert cat == d.ERR_AUTH_INVALID
+
+
+def test_classify_unsupported_url_and_rate_limit():
+    cat, _ = d.classify_deezer_error("Found invalid url: https://x")
+    assert cat == d.ERR_UNSUPPORTED_URL
+    cat, _ = d.classify_deezer_error(
+        "WARNING urllib3.connectionpool api.deezer.com retrying")
+    assert cat == d.ERR_RATE_LIMIT
+
+
+def test_classify_plain_track_failure_and_none():
+    cat, msg = d.classify_deezer_error(
+        "Error downloading track: something else")
+    assert cat == d.ERR_TRACK_FAILURE
+    assert msg is None
+    assert d.classify_deezer_error("Downloading track 'Intro'") == (None, None)
+    assert d.classify_deezer_error("") == (None, None)
+
+
+# ── Sanity: module constants are stable ─────────────────────────────────────
+
+def test_provider_failure_message_is_actionable():
+    assert "Deezer provider failed" in d.PROVIDER_FAILURE_MESSAGE
+    assert "update streamrip" in d.PROVIDER_FAILURE_MESSAGE
+    assert os.linesep not in d.PROVIDER_FAILURE_MESSAGE  # single-line status


### PR DESCRIPTION
## Root cause investigation

The reported symptom — Deezer metadata + cover load fine, but **every track** fails with
`ERROR  Error downloading track: list index out of range`, then `All downloads finished!` —
traces to a single mismatch between Auryn and streamrip.

I installed the supported backend (**streamrip 2.1.0**) and read its source to confirm:

- **`streamrip/client/deezer.py`** — `DeezerClient.get_downloadable()` does:
  ```python
  quality_map = [(9, "MP3_128"), (3, "MP3_320"), (1, "FLAC")]  # 3 rows: indices 0,1,2
  _, format_str = quality_map[quality]                          # no bounds check
  ```
  `DeezerClient.max_quality = 2`, and the bundled `config.toml` documents `[deezer]` quality as
  literally `# 0, 1, or 2`.
- **`streamrip/media/track.py`** reads `quality = config.session.deezer.quality` and passes it
  straight in; the resulting `IndexError` is **not** a `NonStreamableError`, so it propagates to
  **`streamrip/media/album.py`** → `except Exception as e: logger.error(f"Error downloading track: {e}")`.

Meanwhile Auryn's quality selector exposes **5 levels (0–4)** and writes the chosen value verbatim
into **every** service section, including `[deezer]`, on each download. Auryn's default is
`quality_level = 3`. So:

| `[deezer] quality` | `quality_map[quality]` |
|---|---|
| 0 / 1 / 2 | ✅ MP3_128 / MP3_320 / FLAC |
| **3 (FLAC 24/96+)** | ❌ `IndexError: list index out of range` |
| **4 (Max / MQA)** | ❌ `IndexError: list index out of range` |

That is exactly the failure — and because Auryn defaults to 3, **Deezer broke out of the box**.
Metadata/cover still load because they never touch `quality_map`.

Reproduced directly, and verified the fix end-to-end against the real streamrip `Config` loader.

I also audited streamrip's URL parser (**`streamrip/rip/parse_url.py`**) for the secondary
URL/short-link issues:
- `GenericURL` accepts `https://(www|open|play|listen.)?deezer.com/[<locale>/]<type>/<id>`.
- `DeezerDynamicURL` only handles **`https://deezer.page.link/...`**.
- **`link.deezer.com/...` and `dzr.page.link/...` are not supported at all** → confusing failures.
- In streamrip 2.x Deezer **requires an ARL** (`DeezerClient.login()` raises `MissingCredentialsError`
  without one); `use_deezloader` is effectively vestigial.

## What was fixed

Backend unchanged (still `rip url <url>`); the metadata sidebar is untouched.

- **Quality clamp (the fix):** the value written to `[deezer]` is clamped to `2`; other services keep
  the requested quality. The downgrade is logged.
- **New `core/deezer.py`** (GTK-free, dependency-free, unit-tested, mirrors `core/tidal_auth.py`; never
  surfaces the ARL):
  - URL **normalization/validation** against streamrip's real parser — canonicalize content URLs
    (drop locale prefix + tracking query), detect `deezer.page.link` (native) vs unsupported
    `link.deezer.com`/`dzr.page.link` short links, **resolve** share links (public redirect, same
    technique streamrip uses) or **guide** the user, and validate the final URL **before** download.
  - **Config detection** → a clear **"Deezer not configured"** message before download when no ARL is set.
  - **Error classification:** auth missing / auth invalid / unsupported URL / provider failure
    (`list index out of range`) / per-track failure / rate-limit-network.
- **Pre-flight pre-checks** in the download path fail fast with guidance instead of a mid-download crash.
- On `list index out of range`, surface the requested message — *"Deezer provider failed while
  resolving/downloading tracks. Try another Deezer URL format or update streamrip."* — once, while the
  raw streamrip lines stay in the log.
- **"Test Deezer Setup"** button (offline config check; never downloads a full album or reveals the ARL).

## What remains upstream streamrip behavior

- The unguarded `quality_map[quality]` in streamrip itself still raises `IndexError` if fed an
  out-of-range value — Auryn now never feeds it one, but a stricter upstream guard would be ideal.
- `link.deezer.com` / `dzr.page.link` short links remain unsupported by streamrip's parser; Auryn
  resolves them when possible and otherwise guides the user to paste the final `deezer.com` URL.
- Genuine Deezer provider/region/subscription failures, API rate-limiting, and the
  exit-0-with-failed-tracks reporting are streamrip-side; Auryn now classifies and surfaces them clearly.

## Testing

- `python3 -m py_compile src/Auryn.py` ✅
- `pytest` — **77 passed** (28 new in `tests/test_deezer.py`).
- flake8 blocking checks (`E9,F63,F7,F82`) clean.
- End-to-end: simulated Auryn's config-write path for a quality-3 selection → `[deezer] quality = 2`,
  loaded by the real streamrip `Config`, `quality_map[2]` → `FLAC` (no IndexError).
- UI not verified in a running GTK session (no display in this environment).


---
_Generated by [Claude Code](https://claude.ai/code/session_01JoaRgzu3jF2oxEm3xG5SbN)_