### PR TITLE
Clamp download quality per service to prevent streamrip crashes

### DIFF
--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -29,6 +29,7 @@ from core import metadata
 from core import streamrip_status
 from core import log_format
 from core import deezer
+from core import quality as qual
 
 APP_NAME = "Auryn"
 APP_VERSION = "0.1.1"
@@ -91,8 +92,11 @@ separator { background-color: #252525; }
 .history-row:hover { border-color: #333; }
 """
 
-QUALITY_LABELS = ["MP3 128", "MP3 320", "FLAC 16/44.1", "FLAC 24/96+", "Max (MQA)"]
-QUALITY_VALUES = ["0",       "1",       "2",            "3",           "4"]
+# Sourced from core.quality so the picker, the clamping rules and the log
+# messages share one definition (the GTK widget labels live in Auryn.ui and
+# match these exactly).
+QUALITY_LABELS = qual.QUALITY_LABELS
+QUALITY_VALUES = qual.QUALITY_VALUES
 
 # streamrip authenticates the TIDAL client (device/web login) before it ever
 # resolves or downloads a URL, so any syntactically valid TIDAL link is enough
@@ -1583,25 +1587,33 @@ class AurynApp:
                 {"section": "qobuz", "key": "use_auth_token",
                  "value": "true", "quote": False},
             ]
-            # Deezer only supports quality 0..2; streamrip indexes a 3-row
-            # table with this value and crashes ("list index out of range")
-            # for anything higher. Clamp the value written to [deezer] so a
-            # FLAC-24/Max selection downgrades cleanly instead of failing
-            # every track. Other services keep the requested quality.
-            deezer_quality = deezer.clamp_quality(quality)
+            # Each service implements only part of streamrip's 0–4 quality
+            # scale; writing a value above a service's maximum makes streamrip
+            # index its fixed quality table out of bounds and crash ("list
+            # index out of range") on every track (Deezer is the worst case,
+            # max 2). Clamp every section to the range core.quality says the
+            # service supports, so a Max/Hi-Res selection downgrades cleanly
+            # instead of failing. The rules live in core.quality so they are
+            # defined once rather than duplicated per call site.
             for svc in ("qobuz", "tidal", "deezer", "soundcloud"):
-                svc_quality = deezer_quality if svc == "deezer" else quality
                 edits.append({"section": svc, "key": "quality",
-                              "value": str(svc_quality), "quote": False})
+                              "value": str(qual.clamp_quality(svc, quality)),
+                              "quote": False})
 
-            if deezer.is_deezer_url(url) and deezer.quality_was_clamped(quality):
+            active_service = qual.service_for_url(url)
+            if active_service and qual.quality_was_clamped(active_service, quality):
                 GLib.idle_add(
                     self._log,
-                    "ℹ️  Deezer supports up to quality "
-                    f"{deezer.DEEZER_MAX_QUALITY} "
-                    f"({deezer.quality_label(deezer.DEEZER_MAX_QUALITY)}); "
-                    f"using {deezer_quality} for this Deezer download "
-                    f"(requested {quality}).\n", "info")
+                    "ℹ️  " + qual.clamp_message(active_service, quality) + "\n",
+                    "info")
+            elif active_service and qual.is_experimental(active_service, quality):
+                GLib.idle_add(
+                    self._log,
+                    "ℹ️  {} {} is experimental in streamrip.\n".format(
+                        qual.service_display_name(active_service),
+                        qual.quality_label(
+                            qual.clamp_quality(active_service, quality))),
+                    "info")
 
             ok, err, changed = tidal_auth.apply_streamrip_config_updates(
                 cfg, edits)

--- a/src/core/deezer.py
+++ b/src/core/deezer.py
@@ -28,12 +28,15 @@ import os
 import re
 import urllib.request
 
+from core import quality as _quality
+
 # streamrip's ``DeezerClient.max_quality`` (streamrip/client/deezer.py). The
 # quality table there has exactly three rows — 0 = MP3 128, 1 = MP3 320,
 # 2 = FLAC (CD quality) — and ``get_downloadable`` does ``quality_map[quality]``
 # with no bounds check, so a configured quality of 3 or 4 raises
-# ``IndexError: list index out of range`` for every track.
-DEEZER_MAX_QUALITY = 2
+# ``IndexError: list index out of range`` for every track. The supported
+# maximum and the clamping rule are defined once in :mod:`core.quality`.
+DEEZER_MAX_QUALITY = _quality.service_max_quality("deezer")
 
 # Stable, user-facing message for the streamrip provider crash. Defined once so
 # the UI and the tests share a single wording.
@@ -109,36 +112,21 @@ _BARE_HOST_RE = re.compile(
 def clamp_quality(quality):
     """Clamp *quality* into Deezer's supported 0..2 range.
 
-    Accepts ints or numeric strings; anything unparseable falls back to the
-    maximum supported quality. This is the fix that prevents streamrip's
-    ``list index out of range`` crash on Deezer.
+    Deezer-scoped wrapper over :func:`core.quality.clamp_quality`; kept for the
+    Deezer-specific call sites and tests. This is the fix that prevents
+    streamrip's ``list index out of range`` crash on Deezer.
     """
-    try:
-        q = int(str(quality).strip())
-    except (TypeError, ValueError):
-        return DEEZER_MAX_QUALITY
-    if q < 0:
-        return 0
-    if q > DEEZER_MAX_QUALITY:
-        return DEEZER_MAX_QUALITY
-    return q
+    return _quality.clamp_quality("deezer", quality)
 
 
 def quality_was_clamped(quality):
     """True if :func:`clamp_quality` would change *quality*."""
-    try:
-        return int(str(quality).strip()) != clamp_quality(quality)
-    except (TypeError, ValueError):
-        return True
+    return _quality.quality_was_clamped("deezer", quality)
 
 
 def quality_label(quality):
     """Human label for a Deezer quality level."""
-    return {
-        0: "MP3 128 kbps",
-        1: "MP3 320 kbps",
-        2: "FLAC (CD quality)",
-    }.get(quality, str(quality))
+    return _quality.quality_label(quality)
 
 
 # ── URL handling ─────────────────────────────────────────────────────────────

--- a/src/core/quality.py
+++ b/src/core/quality.py
@@ -1,0 +1,170 @@
+"""Service-aware download-quality helpers for Auryn.
+
+streamrip exposes a single 0–4 quality scale, but each music service only
+implements part of it. Writing a value above a service's real maximum makes
+streamrip index its fixed quality table out of bounds and crash
+(``Error downloading track: list index out of range``) on *every* track — most
+visibly for Deezer, whose table has only three rows (0..2).
+
+This module is the single source of truth for "what quality is each service
+allowed to use", so the clamping rules are defined once instead of being
+duplicated across the UI, the Deezer helper and the streamrip-config writer.
+Selecting a quality a service cannot provide is downgraded *cleanly* (clamped
+to the service maximum) with a clear log message rather than failing the
+download.
+
+GTK-free and dependency-free on purpose so it can be exercised by ``--doctor``
+and unit tests without a display, mirroring the isolated-helper pattern of
+``core.deezer`` / ``core.tidal_auth`` / ``core.metadata``.
+"""
+
+import re
+
+# streamrip's universal quality scale (``quality = N`` in config.toml):
+#   0 = MP3/AAC 128 kbps
+#   1 = MP3/AAC 320 kbps
+#   2 = FLAC 16 bit / 44.1 kHz (CD / lossless)
+#   3 = FLAC 24 bit / <=96 kHz (hi-res)
+#   4 = FLAC 24 bit / <=192 kHz (Qobuz "max")
+# These are the canonical, user-facing names; the GTK quality selector uses the
+# same wording (see Auryn.ui) so the picker and the log messages never drift.
+QUALITY_LABELS = ["MP3 128", "MP3 320", "FLAC 16/44.1", "FLAC 24/96+", "Max (MQA)"]
+QUALITY_VALUES = ["0", "1", "2", "3", "4"]
+
+MIN_QUALITY = 0
+MAX_QUALITY = len(QUALITY_VALUES) - 1  # 4 — absolute ceiling of the scale
+
+# Per-service support on the scale above.
+#   ``max``               highest quality streamrip accepts for the service;
+#                         higher selections are clamped down to it.
+#   ``experimental_from`` quality at/above which the tier is flaky/experimental
+#                         in streamrip (currently only TIDAL hi-res), else None.
+#
+# Deezer    : its quality table has 3 rows (0..2); >2 raises IndexError on every
+#             track — the root-cause crash this module exists to prevent.
+# Qobuz     : full range 0..4 (keeps Auryn's current high-quality behaviour).
+# TIDAL     : tops out at hi-res/MQA (3); 4 is not a real TIDAL tier, and the
+#             hi-res tier is treated as experimental.
+# SoundCloud: a single ~128 kbps stream (0); higher values are meaningless.
+_SERVICES = {
+    "deezer":     {"display": "Deezer",     "max": 2, "experimental_from": None},
+    "qobuz":      {"display": "Qobuz",      "max": 4, "experimental_from": None},
+    "tidal":      {"display": "TIDAL",      "max": 3, "experimental_from": 3},
+    "soundcloud": {"display": "SoundCloud", "max": 0, "experimental_from": None},
+}
+
+# The streamrip config sections Auryn writes a quality into, in a stable order.
+SERVICES = tuple(_SERVICES.keys())
+
+# Host-based service detection for quality routing/logging. Deliberately broad
+# (covers share / dynamic-link hosts) and independent of the metadata-oriented
+# ``detect_service_and_id`` in the GTK module.
+_HOST_PATTERNS = (
+    ("deezer", re.compile(
+        r"(?:deezer\.com|deezer\.page\.link|link\.deezer\.com|dzr\.page\.link)",
+        re.I)),
+    ("tidal", re.compile(r"(?:listen\.|play\.)?tidal\.com", re.I)),
+    ("qobuz", re.compile(r"(?:open\.|play\.)?qobuz\.com", re.I)),
+    ("soundcloud", re.compile(r"(?:on\.|m\.)?soundcloud\.com", re.I)),
+)
+
+
+def service_max_quality(service):
+    """Highest quality value streamrip accepts for *service*.
+
+    Unknown services fall back to the full scale (no clamping) so a new
+    streamrip source keeps working until its real ceiling is added here.
+    """
+    return _SERVICES.get(service, {}).get("max", MAX_QUALITY)
+
+
+def service_display_name(service):
+    """Human, correctly-cased service name (e.g. ``"TIDAL"``)."""
+    info = _SERVICES.get(service)
+    if info:
+        return info["display"]
+    return service.title() if service else "This service"
+
+
+def _to_int(quality):
+    return int(str(quality).strip())
+
+
+def clamp_quality(service, quality):
+    """Clamp *quality* into the range *service* actually supports.
+
+    Accepts ints or numeric strings; anything unparseable falls back to the
+    service maximum (a safe, always-valid upper bound). This is the fix that
+    stops streamrip's ``list index out of range`` crash on Deezer and prevents
+    the equivalent out-of-range writes for the other services.
+    """
+    ceiling = service_max_quality(service)
+    try:
+        q = _to_int(quality)
+    except (TypeError, ValueError):
+        return ceiling
+    if q < MIN_QUALITY:
+        return MIN_QUALITY
+    if q > ceiling:
+        return ceiling
+    return q
+
+
+def quality_was_clamped(service, quality):
+    """True if :func:`clamp_quality` would change *quality* for *service*."""
+    try:
+        return _to_int(quality) != clamp_quality(service, quality)
+    except (TypeError, ValueError):
+        return True
+
+
+def quality_label(quality):
+    """Human label for a quality value on the universal scale."""
+    try:
+        q = _to_int(quality)
+    except (TypeError, ValueError):
+        return str(quality)
+    if MIN_QUALITY <= q < len(QUALITY_LABELS):
+        return QUALITY_LABELS[q]
+    return str(q)
+
+
+def is_experimental(service, quality):
+    """True if the (clamped) quality is a flaky/experimental tier for *service*.
+
+    Currently only TIDAL's hi-res/MQA tier; used to surface a gentle note
+    without blocking or downgrading the download.
+    """
+    threshold = _SERVICES.get(service, {}).get("experimental_from")
+    if threshold is None:
+        return False
+    return clamp_quality(service, quality) >= threshold
+
+
+def service_for_url(url):
+    """Best-effort music service for *url* (for quality routing/logging).
+
+    Returns one of the keys in :data:`SERVICES`, or ``None``. Host-based and
+    pure; complements the metadata-oriented detector in the GTK module.
+    """
+    u = (url or "").strip()
+    if not u:
+        return None
+    for service, pattern in _HOST_PATTERNS:
+        if pattern.search(u):
+            return service
+    return None
+
+
+def clamp_message(service, requested):
+    """User-facing note when *requested* is lowered for *service*.
+
+    Example::
+
+        Deezer supports up to FLAC 16/44.1; using FLAC 16/44.1.
+    """
+    used = clamp_quality(service, requested)
+    return "{} supports up to {}; using {}.".format(
+        service_display_name(service),
+        quality_label(service_max_quality(service)),
+        quality_label(used))

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,0 +1,161 @@
+"""Tests for the service-aware quality layer (``core.quality``).
+
+These guard the rule that Auryn must never write a quality value a music
+service does not support: streamrip indexes a fixed per-service quality table
+with the configured value and no bounds check, so an out-of-range value crashes
+every track with ``list index out of range`` (Deezer is the worst case at
+max 2). The module is GTK-free so these run under plain ``pytest`` without
+importing the application module.
+"""
+
+from core import quality as q
+
+
+# ── Per-service supported maximums ──────────────────────────────────────────
+
+def test_service_max_quality_per_service():
+    assert q.service_max_quality("deezer") == 2
+    assert q.service_max_quality("qobuz") == 4
+    assert q.service_max_quality("tidal") == 3
+    assert q.service_max_quality("soundcloud") == 0
+
+
+def test_unknown_service_uses_full_scale_and_does_not_clamp():
+    # A source we don't have a ceiling for must keep working untouched.
+    assert q.service_max_quality("napster") == q.MAX_QUALITY == 4
+    assert q.clamp_quality("napster", 4) == 4
+    assert q.quality_was_clamped("napster", 4) is False
+
+
+def test_services_tuple_lists_every_known_service():
+    assert set(q.SERVICES) == {"deezer", "qobuz", "tidal", "soundcloud"}
+
+
+# ── Clamping ────────────────────────────────────────────────────────────────
+
+def test_deezer_clamps_above_two():
+    assert q.clamp_quality("deezer", 0) == 0
+    assert q.clamp_quality("deezer", 2) == 2
+    assert q.clamp_quality("deezer", 3) == 2  # FLAC 24/96+ — the crash trigger
+    assert q.clamp_quality("deezer", 4) == 2  # Max (MQA)
+
+
+def test_qobuz_keeps_full_high_quality_range():
+    for level in range(0, 5):
+        assert q.clamp_quality("qobuz", level) == level
+
+
+def test_tidal_clamps_unsupported_max_to_hires():
+    assert q.clamp_quality("tidal", 2) == 2
+    assert q.clamp_quality("tidal", 3) == 3  # hi-res / MQA, the real ceiling
+    assert q.clamp_quality("tidal", 4) == 3  # 4 is not a real TIDAL tier
+
+
+def test_soundcloud_uses_safe_default():
+    assert q.clamp_quality("soundcloud", 0) == 0
+    assert q.clamp_quality("soundcloud", 2) == 0
+    assert q.clamp_quality("soundcloud", 4) == 0
+
+
+def test_clamp_handles_strings_negatives_and_garbage():
+    assert q.clamp_quality("deezer", "3") == 2
+    assert q.clamp_quality("qobuz", "4") == 4
+    assert q.clamp_quality("deezer", -1) == 0
+    assert q.clamp_quality("soundcloud", -5) == 0
+    # Unparseable falls back to the (always-valid) service maximum.
+    assert q.clamp_quality("deezer", None) == 2
+    assert q.clamp_quality("deezer", "nonsense") == 2
+    assert q.clamp_quality("qobuz", None) == 4
+
+
+def test_quality_was_clamped_per_service():
+    assert q.quality_was_clamped("deezer", 3) is True
+    assert q.quality_was_clamped("deezer", 4) is True
+    assert q.quality_was_clamped("deezer", 2) is False
+    assert q.quality_was_clamped("qobuz", 4) is False
+    assert q.quality_was_clamped("tidal", 4) is True
+    assert q.quality_was_clamped("tidal", 3) is False
+    assert q.quality_was_clamped("soundcloud", 1) is True
+    assert q.quality_was_clamped("soundcloud", 0) is False
+    # Garbage counts as "would change".
+    assert q.quality_was_clamped("deezer", "nonsense") is True
+
+
+# ── Labels ──────────────────────────────────────────────────────────────────
+
+def test_quality_label_matches_ui_wording():
+    assert q.quality_label(0) == "MP3 128"
+    assert q.quality_label(1) == "MP3 320"
+    assert q.quality_label(2) == "FLAC 16/44.1"
+    assert q.quality_label(3) == "FLAC 24/96+"
+    assert q.quality_label(4) == "Max (MQA)"
+    assert q.quality_label("2") == "FLAC 16/44.1"
+    # Out-of-scale / garbage degrades to a string instead of raising.
+    assert q.quality_label(9) == "9"
+    assert q.quality_label("nope") == "nope"
+
+
+def test_labels_and_values_stay_aligned():
+    assert len(q.QUALITY_LABELS) == len(q.QUALITY_VALUES) == 5
+    assert q.QUALITY_VALUES == ["0", "1", "2", "3", "4"]
+
+
+# ── Experimental tiers ──────────────────────────────────────────────────────
+
+def test_tidal_hires_is_experimental():
+    assert q.is_experimental("tidal", 3) is True
+    assert q.is_experimental("tidal", 4) is True  # clamped to 3, still hi-res
+    assert q.is_experimental("tidal", 2) is False
+
+
+def test_other_services_are_not_experimental():
+    assert q.is_experimental("deezer", 2) is False
+    assert q.is_experimental("qobuz", 4) is False
+    assert q.is_experimental("soundcloud", 0) is False
+    assert q.is_experimental("unknown", 4) is False
+
+
+# ── URL → service routing ───────────────────────────────────────────────────
+
+def test_service_for_url_detects_each_service():
+    assert q.service_for_url("https://www.deezer.com/album/302127") == "deezer"
+    assert q.service_for_url("https://deezer.page.link/abc") == "deezer"
+    assert q.service_for_url("https://link.deezer.com/s/abc") == "deezer"
+    assert q.service_for_url("https://tidal.com/browse/album/1") == "tidal"
+    assert q.service_for_url("https://listen.tidal.com/album/1") == "tidal"
+    assert q.service_for_url("https://open.qobuz.com/album/abc") == "qobuz"
+    assert q.service_for_url("https://soundcloud.com/artist/track") == "soundcloud"
+
+
+def test_service_for_url_returns_none_for_unknown_or_empty():
+    assert q.service_for_url("https://example.com/album/1") is None
+    assert q.service_for_url("") is None
+    assert q.service_for_url(None) is None
+
+
+# ── User-facing clamp message ───────────────────────────────────────────────
+
+def test_clamp_message_matches_required_wording():
+    # The exact wording the task pins down for a downgraded Deezer download.
+    assert q.clamp_message("deezer", 3) == (
+        "Deezer supports up to FLAC 16/44.1; using FLAC 16/44.1.")
+    assert q.clamp_message("deezer", 4) == (
+        "Deezer supports up to FLAC 16/44.1; using FLAC 16/44.1.")
+
+
+def test_clamp_message_per_service():
+    assert q.clamp_message("tidal", 4) == (
+        "TIDAL supports up to FLAC 24/96+; using FLAC 24/96+.")
+    assert q.clamp_message("soundcloud", 3) == (
+        "SoundCloud supports up to MP3 128; using MP3 128.")
+
+
+# ── Cross-check: the Deezer wrapper delegates here ──────────────────────────
+
+def test_deezer_helpers_delegate_to_central_logic():
+    from core import deezer
+
+    assert deezer.DEEZER_MAX_QUALITY == q.service_max_quality("deezer") == 2
+    assert deezer.clamp_quality(4) == q.clamp_quality("deezer", 4) == 2
+    assert deezer.quality_was_clamped(3) is True
+    assert deezer.quality_label(2) == q.quality_label(2) == "FLAC 16/44.1"


### PR DESCRIPTION
## Summary

Auryn could write a quality value a music service doesn't support into streamrip's `config.toml`. streamrip indexes a fixed per-service quality table with that value and has no bounds check, so an out-of-range value crashes **every track** with `Error downloading track: list index out of range`. Deezer (which only supports `0`, `1`, `2`) was the worst case, but the same class of bug applies to the other services.

This PR introduces a single source of truth for per-service quality ranges and clamps the value written to each streamrip config section, with a clear log message when a selection is lowered.

## What changed

- **New `src/core/quality.py`** — central, GTK-free helper (mirrors the `core.deezer` / `core.tidal_auth` isolated-helper pattern). Defines the supported range per service and the clamping/labelling/logging rules in one place:
  | Service | Max | Notes |
  |---|---|---|
  | Deezer | `2` (FLAC 16/44.1) | table has 3 rows; `>2` is the crash trigger |
  | Qobuz | `4` (Max) | full range preserved — current high-quality behaviour |
  | TIDAL | `3` (hi-res/MQA) | `4` is not a real TIDAL tier; hi-res marked **experimental** |
  | SoundCloud | `0` (~128 kbps) | single-stream service — safe default |
  | *unknown* | `4` | no clamping, so a future streamrip source keeps working |
- **`_run_download`** now clamps every service section via `core.quality` instead of only `[deezer]`, and logs e.g. `Deezer supports up to FLAC 16/44.1; using FLAC 16/44.1.` when it lowers the quality for the URL's service. TIDAL hi-res gets a one-line "experimental" note.
- **`core.deezer`** keeps its public API (`clamp_quality`, `quality_was_clamped`, `quality_label`, `DEEZER_MAX_QUALITY`) but now **delegates** to `core.quality`, so the rule isn't duplicated.
- **UI label constants** (`QUALITY_LABELS` / `QUALITY_VALUES`) are sourced from `core.quality`. The GTK widget labels in `Auryn.ui` are unchanged and already match these strings.

## Scope / non-goals

- **Download logic is untouched** — only the quality value written to config is clamped before launching streamrip.
- **The right-side metadata/cover panel is untouched.**
- **UI labels are unchanged.**

## Decision worth a look (TIDAL)

The task said "keep current behavior but mark experimental if needed." TIDAL's real streamrip ceiling is `3` (hi-res/MQA); `4` is not a valid TIDAL tier, so writing it risks the same out-of-range crash. I kept `0–3` behaving exactly as today (no clamp for anything a TIDAL account can actually use) and only clamp the genuinely-invalid `4 → 3`, plus a small "experimental" log note for the hi-res tier. Happy to instead leave TIDAL fully unclamped (max `4`) if you'd prefer the literal current behaviour.

## Test plan

- [x] `python3 -m py_compile src/Auryn.py`
- [x] `pytest` — 95 passed (18 new in `tests/test_quality.py` covering per-service clamping, label/wording, URL→service routing, experimental tiers, and the Deezer-wrapper delegation; existing Deezer tests still green)
- [ ] Manual GTK run not possible in this environment (no display); behaviour verified via the `core.quality` unit tests and an end-to-end clamp/log simulation.

https://claude.ai/code/session_01JaxeBhc77tBYcWBPJVTwFN

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaxeBhc77tBYcWBPJVTwFN)_