### PR TITLE
Treat Deezer as a recommended service in setup UI

### DIFF
--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -3046,7 +3046,10 @@ class AurynApp:
         sel_lbl = Gtk.Label()
         sel_lbl.set_markup('<span foreground="#888888" size="small">Service</span>')
         combo = Gtk.ComboBoxText()
-        for sid, label in (("qobuz", "Qobuz"), ("deezer", "Deezer"), ("tidal", "TIDAL")):
+        # Deezer first and flagged as recommended (large catalog, simplest setup
+        # — a single ARL token). Qobuz/TIDAL remain fully available.
+        for sid, label in (("deezer", deezer.RECOMMENDED_LABEL),
+                           ("qobuz", "Qobuz"), ("tidal", "TIDAL")):
             combo.append(sid, label)
         combo.set_active(0)
         sel_row.pack_start(sel_lbl, False, False, 0)
@@ -3191,6 +3194,12 @@ class AurynApp:
                 state["entries"] = {"email": email_entry, "password": pass_entry}
 
             elif service == "deezer":
+                rec = deezer.RECOMMENDED_NOTE.replace("&", "&amp;").replace(
+                    "<", "&lt;").replace(">", "&gt;")
+                body.pack_start(note(
+                    '<span foreground="#4CAF50" size="small">'
+                    f'⭐  {rec}</span>'
+                ), False, False, 0)
                 grid = Gtk.Grid()
                 grid.set_column_spacing(12)
                 grid.set_row_spacing(8)
@@ -3234,6 +3243,14 @@ class AurynApp:
                     'Test Deezer Setup checks your saved configuration only '
                     '(ARL present, quality in range). It never downloads a '
                     'full album or reveals your ARL.</span>'
+                ), False, False, 0)
+                guidance = "\n".join(
+                    "• " + g.replace("&", "&amp;").replace(
+                        "<", "&lt;").replace(">", "&gt;")
+                    for g in deezer.url_guidance())
+                body.pack_start(note(
+                    '<span foreground="#888888" size="small">'
+                    f'<b>Pasting Deezer links:</b>\n{guidance}</span>'
                 ), False, False, 0)
                 state["entries"] = {"arl": arl_entry}
 
@@ -3315,7 +3332,7 @@ class AurynApp:
                 render(sid)
 
         combo.connect("changed", on_combo_changed)
-        render("qobuz")
+        render("deezer")
         dlg.show_all()
 
         while True:

--- a/src/core/deezer.py
+++ b/src/core/deezer.py
@@ -45,6 +45,31 @@ PROVIDER_FAILURE_MESSAGE = (
     "Try another Deezer URL format or update streamrip."
 )
 
+# Auryn recommends Deezer: a large catalog and the simplest setup (a single ARL
+# token, versus TIDAL's device-auth flow), which also suits the NAS/local-
+# library workflow better than TIDAL auth. Surfaced in the UI so first-time
+# users start with the service most likely to "just work". Wording lives here so
+# the UI and the tests stay in sync.
+RECOMMENDED = True
+RECOMMENDED_LABEL = "Deezer (Recommended)"
+RECOMMENDED_NOTE = (
+    "Deezer is the recommended service for Auryn — a large catalog and the "
+    "simplest setup: paste one ARL token and you're ready."
+)
+
+
+def url_guidance():
+    """User-facing guidance for pasting Deezer URLs (shared by UI and tests).
+
+    Returns a list of single-line strings. Never contains secrets.
+    """
+    return [
+        "Prefer a direct deezer.com album, track or playlist URL "
+        "(e.g. https://www.deezer.com/album/302127).",
+        "If you have a link.deezer.com (or dzr.page.link) share link, open it "
+        "in your browser and paste the final deezer.com URL it lands on.",
+    ]
+
 # URL classification kinds returned by :func:`classify_deezer_url`.
 NOT_DEEZER = "not_deezer"      # not a Deezer URL at all
 CONTENT = "content"            # canonical album/track/playlist/artist URL

--- a/tests/test_deezer.py
+++ b/tests/test_deezer.py
@@ -288,6 +288,34 @@ def test_classify_plain_track_failure_and_none():
     assert d.classify_deezer_error("") == (None, None)
 
 
+# ── Recommended-service treatment ───────────────────────────────────────────
+
+def test_recommended_flag_and_label():
+    assert d.RECOMMENDED is True
+    assert "Recommended" in d.RECOMMENDED_LABEL
+    assert d.RECOMMENDED_LABEL.startswith("Deezer")
+
+
+def test_recommended_note_is_single_line_and_secret_free():
+    assert d.RECOMMENDED_NOTE
+    assert "\n" not in d.RECOMMENDED_NOTE
+    assert "arl" not in d.RECOMMENDED_NOTE.lower() or "ARL token" in d.RECOMMENDED_NOTE
+
+
+def test_url_guidance_covers_direct_and_share_links():
+    lines = d.url_guidance()
+    assert isinstance(lines, list) and len(lines) >= 2
+    joined = " ".join(lines).lower()
+    # Prefer a direct deezer.com URL …
+    assert "deezer.com" in joined
+    # … and explain the share-link → browser → final-URL workaround.
+    assert "link.deezer.com" in joined
+    assert "browser" in joined
+    # Guidance must stay single-line per entry (rendered as bullet list).
+    for line in lines:
+        assert "\n" not in line
+
+
 # ── Sanity: module constants are stable ─────────────────────────────────────
 
 def test_provider_failure_message_is_actionable():


### PR DESCRIPTION
## What was improved

Auryn already had a solid Deezer support layer (quality clamping to 0–2, ARL detection without ever surfacing the token, URL normalization/validation, share-link resolution, a **Test Deezer Setup** action, and friendly error classification). This PR closes the one remaining gap from the requirements: **treating Deezer as a first-class, recommended service in the UI.**

- **Recommended in the service picker** — Deezer now leads the Setup → Service dropdown and is labelled **"Deezer (Recommended)"**, and the dialog opens on Deezer by default. Qobuz and TIDAL remain fully selectable and unchanged.
- **Recommended note** — the Deezer setup panel shows why it's recommended (large catalog, simplest setup: one ARL token).
- **URL-pasting guidance** in the panel:
  - Prefer a direct `deezer.com` album/track/playlist URL.
  - If you have a `link.deezer.com` / `dzr.page.link` share link, open it in a browser and paste the final `deezer.com` URL it lands on.
- Wording lives once in `core.deezer` (`RECOMMENDED`, `RECOMMENDED_LABEL`, `RECOMMENDED_NOTE`, `url_guidance()`) so the UI and tests share a single source of truth. All strings are Pango-escaped at the call site.

### Preserved as required
- The core streamrip download pipeline is untouched.
- The right-side cover/metadata sidebar is untouched.
- Qobuz (email/password) and TIDAL (device auth) setup flows are unchanged.
- No ARL/token is ever logged, rendered, or returned — the new strings are secret-free and tested for it.

### Tests
- New tests in `tests/test_deezer.py` cover the recommended flag/label, that the note is single-line and secret-free, and that the URL guidance covers both the direct-link preference and the share-link → browser workaround.
- Full suite: **98 passed**. `python3 -m py_compile src/Auryn.py` is clean.

## Deezer limitations that remain (upstream streamrip behaviour)

- **Quality ceiling 0–2.** streamrip's `DeezerClient` indexes a fixed three-row quality table with no bounds check, so any configured quality > 2 raises `list index out of range` on *every* track. Auryn clamps Deezer to ≤ 2 (in `core.quality`) — this PR does not change that and cannot raise the ceiling; it's a streamrip constraint.
- **Share links aren't understood natively.** streamrip's URL parser accepts `deezer.com/<type>/<id>` and `deezer.page.link/...` but not `link.deezer.com` / `dzr.page.link`. Auryn resolves these where possible, but a share link that only resolves in an authenticated browser session must be opened manually — hence the guidance text.
- **ARL is required and can expire.** streamrip authenticates Deezer with an ARL cookie; an expired/invalid ARL fails at download time (Auryn surfaces this as a clear "invalid or expired — update it in Setup" message). Auryn cannot refresh the ARL for you.

## How to test Deezer manually

1. Open **Setup → Credentials**. The service picker should default to **Deezer (Recommended)**; you should see the recommended note and the "Pasting Deezer links" guidance.
2. Paste your Deezer **ARL** and **Save**. Click **Test Deezer Setup** — it should report Deezer looks ready *without* echoing the ARL.
3. Without an ARL, **Test Deezer Setup** should report "not configured — no ARL found".
4. Queue a direct URL, e.g. `https://www.deezer.com/album/302127`, and download — verify the metadata sidebar populates and the download completes.
5. Paste a `link.deezer.com/...` share link — Auryn should attempt to resolve it, and if it can't, point you to open it in a browser and paste the final `deezer.com` URL.
6. Set the quality picker to a hi-res tier and download Deezer — confirm the log shows the clamp-to-FLAC-16/44.1 note and the download succeeds (no `list index out of range`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NARc4BS9bSfU8qnx9TPUmq)_