### PR TITLE
Organize downloads into a clean NAS/Jellyfin-friendly library

### DIFF
--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -14,6 +14,7 @@ import urllib.request
 import json
 import tempfile
 import platform
+import shutil
 import sys
 import io
 import time
@@ -28,6 +29,7 @@ from core import metadata
 from core import streamrip_status
 from core import log_format
 from core import deezer
+from core import library
 from core import quality as qual
 from core import streamrip_exec
 
@@ -126,6 +128,16 @@ def detect_service_and_id(url):
     return (None, None)
 
 
+def url_is_playlist(url):
+    """Best-effort: True if *url* points at a playlist rather than an album.
+
+    Used only to route post-download organisation (playlists go under a
+    dedicated folder). SoundCloud calls them "sets". Conservative: anything
+    not clearly a playlist is treated as an album/track.
+    """
+    return bool(re.search(r'/(?:playlist|sets)/', url or "", re.I))
+
+
 def fetch_qobuz_meta(album_id):
     urls_to_try = [
         f"https://www.qobuz.com/api.json/0.2/album/get?album_id={album_id}&limit=50",
@@ -216,6 +228,13 @@ def is_first_launch():
 DEFAULT_CONFIG = {
     "download_folder": os.path.expanduser("~/Music"),
     "quality_level": 3,
+    # Organise finished downloads into a tidy NAS / Jellyfin / Symfonium
+    # library tree (<Album Artist>/<Album>/<Quality>/…). Post-processing only;
+    # the streamrip download pipeline is untouched, and on any failure the
+    # original files are left exactly where streamrip wrote them.
+    "organize_library": True,
+    # Group playlists under a dedicated "Playlists" folder.
+    "playlists_subfolder": True,
 }
 
 
@@ -388,6 +407,8 @@ class AurynApp:
         self.btn_log       = self.builder.get_object("btn_open_log")
         self.btn_copy_log  = self.builder.get_object("btn_copy_log")
         self.cb_clear_cache = self.builder.get_object("cb_clear_cache")
+        self.cb_organize    = self.builder.get_object("cb_organize_library")
+        self.cb_playlists_subfolder = self.builder.get_object("cb_playlists_subfolder")
         self.folder_lbl    = self.builder.get_object("folder_lbl")
         self.status_lbl    = self.builder.get_object("status_lbl")
         self.progress_bar  = self.builder.get_object("progress_bar")
@@ -448,6 +469,10 @@ class AurynApp:
         self._dl_invalid_url        = False
         self._dl_finished_marker    = False
         self._cfg_fingerprint_pre   = None
+        # Context captured per-download for post-download library organisation.
+        self._album_meta            = None
+        self._active_is_playlist    = False
+        self._active_quality        = None
 
         # ── Forcer can-focus sur les widgets interactifs ──
         self.url_entry.set_can_focus(True)
@@ -466,6 +491,10 @@ class AurynApp:
         self.btn_add_queue.set_can_focus(True)
         self.btn_clear_queue.set_can_focus(True)
         self.cb_clear_cache.set_can_focus(True)
+        if self.cb_organize is not None:
+            self.cb_organize.set_can_focus(True)
+        if self.cb_playlists_subfolder is not None:
+            self.cb_playlists_subfolder.set_can_focus(True)
         for cb in self._quality_checks:
             cb.set_can_focus(True)
 
@@ -500,6 +529,12 @@ class AurynApp:
 
         for i, cb in enumerate(self._quality_checks):
             cb.connect("toggled", self._on_quality_toggled, i)
+
+        if self.cb_organize is not None:
+            self.cb_organize.connect("toggled", self._on_organize_toggled)
+        if self.cb_playlists_subfolder is not None:
+            self.cb_playlists_subfolder.connect("toggled",
+                                                self._on_organize_toggled)
 
         # ── Restaurer les préférences enregistrées ──
         self._apply_saved_preferences()
@@ -538,12 +573,33 @@ class AurynApp:
                 cb.set_active(i == quality_idx)
                 cb.handler_unblock_by_func(self._on_quality_toggled)
 
+        if self.cb_organize is not None:
+            self.cb_organize.handler_block_by_func(self._on_organize_toggled)
+            self.cb_organize.set_active(
+                bool(self._config.get("organize_library", True)))
+            self.cb_organize.handler_unblock_by_func(self._on_organize_toggled)
+        if self.cb_playlists_subfolder is not None:
+            self.cb_playlists_subfolder.handler_block_by_func(
+                self._on_organize_toggled)
+            self.cb_playlists_subfolder.set_active(
+                bool(self._config.get("playlists_subfolder", True)))
+            self.cb_playlists_subfolder.handler_unblock_by_func(
+                self._on_organize_toggled)
+
+    def _on_organize_toggled(self, *_):
+        self._persist_preferences()
+
     def _persist_preferences(self):
         self._config["download_folder"] = self._dest_folder
         for i, cb in enumerate(self._quality_checks):
             if cb.get_active():
                 self._config["quality_level"] = i
                 break
+        if self.cb_organize is not None:
+            self._config["organize_library"] = self.cb_organize.get_active()
+        if self.cb_playlists_subfolder is not None:
+            self._config["playlists_subfolder"] = \
+                self.cb_playlists_subfolder.get_active()
         try:
             save_config(self._config)
         except OSError as e:
@@ -967,6 +1023,9 @@ class AurynApp:
         self._track_done       = 0
         self._total_tracks     = 0
         self._last_known_error = None
+        self._album_meta          = None
+        self._active_is_playlist  = url_is_playlist(url)
+        self._active_quality      = None
         self._reset_streamrip_signals()
         self._set_status("⏳  Fetching album info...", "info")
         self._set_lyrics('<span foreground="#555555"><i>Lyrics appear here once a track is identified.</i></span>')
@@ -986,6 +1045,9 @@ class AurynApp:
             url = self._prepare_deezer_url(url)
             if url is None:
                 return  # pre-check failed; UI/queue already updated
+        # The (possibly normalised / resolved) URL is now final; refine the
+        # album-vs-playlist routing used by post-download organisation.
+        self._active_is_playlist = url_is_playlist(url)
         service, item_id = detect_service_and_id(url)
         if service == "qobuz" and item_id:
             GLib.idle_add(self._set_status, "⏳  Fetching metadata...", "info")
@@ -1160,8 +1222,24 @@ class AurynApp:
         except Exception:
             pass
 
+    def _remember_album_meta(self, fields):
+        """Stash untruncated album artist/title for post-download organisation.
+
+        The sidebar labels are truncated for display, so the library organiser
+        relies on these full values to build folder names. Never raises on a
+        partial payload.
+        """
+        try:
+            artist = (fields.get("artist") or "").strip()
+            album = (fields.get("album") or "").strip()
+        except AttributeError:
+            return
+        if artist or album:
+            self._album_meta = {"artist": artist, "album": album}
+
     def _apply_deezer_meta(self, data):
         fields = metadata.deezer_album_fields(data)
+        self._remember_album_meta(fields)
         # Deezer values are kept slightly shorter to fit the historical layout.
         self._set_meta("Album Artist",  fields["artist"],       limit=28)
         self._set_meta("Album",         fields["album"],        limit=28)
@@ -1178,6 +1256,7 @@ class AurynApp:
 
     def _apply_qobuz_meta(self, data):
         fields = metadata.qobuz_album_fields(data)
+        self._remember_album_meta(fields)
         self._set_meta("Album Artist",  fields["artist"])
         self._set_meta("Album",         fields["album"])
         self._set_meta("Total Tracks",  fields["total_tracks"])
@@ -1646,6 +1725,7 @@ class AurynApp:
         db = os.path.join(os.path.dirname(cfg), "downloads.db")
 
         self._active_url = url
+        self._active_quality = quality
         self._tidal_auth_required = False
         self._tidal_auth_corrupted = False
         self._tb_noise_notified = False
@@ -2181,11 +2261,220 @@ class AurynApp:
         except Exception as exc:
             self._set_status(f"❌  Could not copy log: {exc}", "error")
 
+    # ── Post-download library organisation ────────────────────────────────
+    #
+    # Reorganise streamrip's finished output into a predictable
+    # NAS / Jellyfin / Symfonium library tree:
+    #
+    #   <Album Artist>/<Album Title>/<Quality>/NN. <Artist> - <Title>.<ext>
+    #   Playlists/<Playlist Name>/NN. <Artist> - <Title>.<ext> + playlist.m3u
+    #
+    # This is pure post-processing: the streamrip download pipeline is never
+    # touched, so Deezer/Qobuz downloads and the metadata sidebar are
+    # unaffected. It runs ONLY after a successful or partial download (files
+    # are no longer being written), preserves streamrip's track names, track
+    # numbers, embedded tags and cover.jpg, never overwrites a different file,
+    # and on ANY failure leaves every file exactly where streamrip wrote it.
+    #
+    # FLAC bit-depth / sample-rate per streamrip quality tier (2..4), used to
+    # label the <Quality> folder for lossless downloads. Lossy formats get a
+    # container-only label (MP3/AAC have no meaningful bit depth).
+    _FLAC_QUALITY_SPECS = {2: (16, 44100), 3: (24, 96000), 4: (24, 192000)}
+
+    def _organize_download(self, folder):
+        """Reorganise *folder* into the library tree; return the recorded folder.
+
+        *folder* is the directory streamrip created under the destination.
+        Returns the (possibly new) top-level folder to show in history, or the
+        original folder unchanged when organisation is disabled, not
+        applicable, or failed. Files are never deleted on failure.
+        """
+        base = self._dest_folder
+        if not folder or not os.path.isdir(folder):
+            return folder
+        # Only relocate a freshly-created subfolder; never reorganise the
+        # destination root itself (that could sweep up unrelated files).
+        if os.path.abspath(folder) == os.path.abspath(base):
+            self._log(f"📂  Files saved to: {folder}\n", "info")
+            return folder
+        if not self._config.get("organize_library", True):
+            self._log(f"📂  Files saved to: {folder}\n", "info")
+            return folder
+        try:
+            if self._active_is_playlist:
+                result = self._organize_playlist(base, folder)
+            else:
+                result = self._organize_album(base, folder)
+        except Exception as exc:
+            self._log(
+                "⚠  Download finished, but library organization failed — "
+                "files were left in the original output folder.\n", "error")
+            self._log(f"    {folder}\n", "dim")
+            self._log(f"    ({type(exc).__name__}: {exc})\n", "dim")
+            return folder
+        if not result:
+            self._log(f"📂  Files saved to: {folder}\n", "info")
+            return folder
+        kind = "playlist" if self._active_is_playlist else "album"
+        self._log(f"🗂  Organized {kind} into library:\n    {result}\n", "ok")
+        return result
+
+    def _organize_album(self, base, folder):
+        meta = self._album_meta or {}
+        artist = meta.get("artist", "")
+        album = meta.get("album", "")
+        # Without album metadata we cannot build a clean artist/album path;
+        # leave the files where streamrip put them (no scary warning).
+        if not artist and not album:
+            return None
+        files = self._collect_files(folder)
+        if not files:
+            return None
+        names = [os.path.basename(p) for p in files]
+        quality = self._quality_folder_label(names)
+        moves = library.plan_album_layout(
+            names,
+            album_artist=artist or library.FALLBACK_ARTIST,
+            album_title=album or library.FALLBACK_ALBUM,
+            quality=quality,
+        )
+        abs_moves = [(src, os.path.join(base, *dst.split("/")))
+                     for src, (_name, dst) in zip(files, moves)]
+        self._execute_moves(abs_moves)
+        self._cleanup_empty_dirs(folder, base)
+        # Album-level folder (parent of the quality folder) for history.
+        parts = moves[0][1].split("/")
+        return os.path.join(base, *parts[:2])
+
+    def _organize_playlist(self, base, folder):
+        files = self._sort_playlist_files(self._collect_files(folder))
+        if not files:
+            return None
+        names = [os.path.basename(p) for p in files]
+        in_subfolder = self._config.get("playlists_subfolder", True)
+        parent = library.PLAYLISTS_DIR if in_subfolder else ""
+        plan = library.plan_playlist_layout(
+            names,
+            playlist_name=self._playlist_name(folder),
+            service=qual.service_for_url(self._active_url) or None,
+            playlist_id=self._playlist_id(),
+            parent=parent,
+        )
+        abs_moves = [(src, os.path.join(base, *dst.split("/")))
+                     for src, (_name, dst) in zip(files, plan["moves"])]
+        self._execute_moves(abs_moves)
+        dest_dir = os.path.join(base, *plan["folder"].split("/"))
+        self._write_playlist_m3u(dest_dir, plan["audio"])
+        self._cleanup_empty_dirs(folder, base)
+        return dest_dir
+
+    def _quality_folder_label(self, names):
+        """Build the <Quality> folder label from the files actually written."""
+        container = library.dominant_container(names) or "Audio"
+        bit = rate = None
+        if container == "FLAC":
+            service = qual.service_for_url(self._active_url)
+            clamped = (qual.clamp_quality(service, self._active_quality)
+                       if service else self._active_quality)
+            try:
+                spec = self._FLAC_QUALITY_SPECS.get(int(clamped))
+            except (TypeError, ValueError):
+                spec = None
+            if spec:
+                bit, rate = spec
+        return library.quality_folder(container, bit, rate)
+
+    @staticmethod
+    def _collect_files(folder):
+        """All files under *folder* (recursive), as absolute paths."""
+        collected = []
+        for root, _dirs, names in os.walk(folder):
+            for name in names:
+                collected.append(os.path.join(root, name))
+        return collected
+
+    @staticmethod
+    def _sort_playlist_files(files):
+        """Order files by their leading track number so playlist order holds."""
+        def key(path):
+            name = os.path.basename(path)
+            m = re.match(r'\s*(\d+)', name)
+            if m:
+                return (0, int(m.group(1)), name.lower())
+            return (1, 0, name.lower())
+        return sorted(files, key=key)
+
+    def _playlist_name(self, folder):
+        """Playlist name from streamrip's folder (it names it after the list)."""
+        return os.path.basename(os.path.normpath(folder))
+
+    def _playlist_id(self):
+        m = re.search(r'/(?:playlist|sets)/([\w-]+)',
+                      self._active_url or "", re.I)
+        return m.group(1) if m else None
+
+    def _execute_moves(self, abs_moves):
+        """Move each ``(src, dst)``; never overwrite a different file."""
+        for src, dst in abs_moves:
+            if os.path.abspath(src) == os.path.abspath(dst):
+                continue
+            if not os.path.exists(src):
+                continue
+            dst_dir = os.path.dirname(dst)
+            os.makedirs(dst_dir, exist_ok=True)
+            final = dst
+            if os.path.exists(final):
+                # Same content (e.g. a re-download) → keep the existing file.
+                try:
+                    if os.path.getsize(final) == os.path.getsize(src):
+                        os.remove(src)
+                        continue
+                except OSError:
+                    pass
+                # Different content → never overwrite; pick a unique name.
+                try:
+                    existing = set(os.listdir(dst_dir))
+                except OSError:
+                    existing = set()
+                final = os.path.join(
+                    dst_dir,
+                    library.dedupe_filename(os.path.basename(dst), existing))
+            shutil.move(src, final)
+
+    def _write_playlist_m3u(self, dest_dir, audio_names):
+        """Write playlist.m3u listing *audio_names* in order (best-effort)."""
+        if not audio_names:
+            return
+        try:
+            body = library.m3u_content(audio_names)
+            path = os.path.join(dest_dir, library.PLAYLIST_FILE)
+            tmp = path + ".tmp"
+            with open(tmp, "w", encoding="utf-8") as fh:
+                fh.write(body)
+            os.replace(tmp, path)
+        except OSError as exc:
+            self._log(f"⚠  Could not write {library.PLAYLIST_FILE}: {exc}\n",
+                      "error")
+
+    @staticmethod
+    def _cleanup_empty_dirs(folder, base):
+        """Remove directories emptied by the move, never the destination root."""
+        base_abs = os.path.abspath(base)
+        for root, _dirs, _files in os.walk(folder, topdown=False):
+            if os.path.abspath(root) == base_abs:
+                continue
+            try:
+                if not os.listdir(root):
+                    os.rmdir(root)
+            except OSError:
+                pass
+
     def _finish_full_success(self):
         self._set_status("✅  Download complete!", "ok")
         self.progress_bar.set_fraction(1.0)
         self._log("\n✅  All downloads finished!\n", "ok")
         folder = self._detect_new_folder(self._dest_folder, self._dest_dirs_snapshot) or self._dest_folder
+        folder = self._organize_download(folder)
         self._history_set_status(self._current_history_entry, "Completed", folder=folder)
         self._queue_set_status(self._current_queue_item, "Completed")
 
@@ -2200,6 +2489,8 @@ class AurynApp:
         # Some tracks may still have landed; keep the folder link if one
         # was created so partial results stay reachable.
         folder = self._detect_new_folder(self._dest_folder, self._dest_dirs_snapshot)
+        if folder:
+            folder = self._organize_download(folder)
         self._history_set_status(self._current_history_entry, "Warning", folder=folder)
         self._queue_set_status(self._current_queue_item, "Warning")
 

--- a/src/Auryn.ui
+++ b/src/Auryn.ui
@@ -394,6 +394,36 @@
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkCheckButton" id="cb_organize_library">
+                    <property name="label">Organize downloads for music libraries</property>
+                    <property name="tooltip-text">Sort finished downloads into Album Artist / Album / Quality folders (and Playlists for playlists)</property>
+                    <property name="can-focus">False</property>
+                    <property name="receives-default">False</property>
+                    <property name="active">True</property>
+                    <property name="draw-indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">5</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="cb_playlists_subfolder">
+                    <property name="label">Put playlists in a Playlists folder</property>
+                    <property name="tooltip-text">Group downloaded playlists under a dedicated Playlists folder</property>
+                    <property name="can-focus">False</property>
+                    <property name="receives-default">False</property>
+                    <property name="active">True</property>
+                    <property name="draw-indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">6</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkBox" id="btn_row">
                     <property name="can-focus">False</property>
                     <property name="spacing">8</property>
@@ -443,7 +473,7 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
-                    <property name="position">5</property>
+                    <property name="position">7</property>
                   </packing>
                 </child>
                 <child>
@@ -457,7 +487,7 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
-                    <property name="position">6</property>
+                    <property name="position">8</property>
                   </packing>
                 </child>
                 <child>
@@ -467,7 +497,7 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
-                    <property name="position">7</property>
+                    <property name="position">9</property>
                   </packing>
                 </child>
                 <child>
@@ -715,7 +745,7 @@
                   <packing>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
-                    <property name="position">8</property>
+                    <property name="position">10</property>
                   </packing>
                 </child>
               </object>

--- a/src/core/library.py
+++ b/src/core/library.py
@@ -1,0 +1,350 @@
+"""Pure, GTK-free helpers for organising downloads into a tidy music library.
+
+After streamrip finishes a download, Auryn can reorganise the files into a
+predictable NAS / Jellyfin / Symfonium-friendly layout:
+
+    Music/<Album Artist>/<Album Title>/<Quality>/NN. <Artist> - <Title>.<ext>
+                                                 cover.jpg
+
+    Music/Playlists/<Playlist Name>/NN. <Artist> - <Title>.<ext>
+                                    playlist.m3u
+                                    cover.jpg
+
+This module owns *only* the name/path computation and the move *planning*. It
+performs no file I/O, no GTK and no network, so every rule (filesystem-safe
+names, Windows reserved names, duplicate handling, album/playlist layout) can
+be unit-tested in isolation. The GTK application module executes the returned
+plan and is the only place that actually touches the disk — keeping the risky
+part small and the logic here pure, mirroring the isolated-helper pattern of
+``core.metadata`` / ``core.quality`` / ``core.streamrip_status``.
+
+The download pipeline itself is never touched: streamrip writes files exactly
+as it always has (embedded tags, cover.jpg, track numbers in the name), and
+organisation only relocates the finished files. Reorganisation is designed to
+be safe:
+
+  * Names are sanitised for both Linux and Windows (forbidden characters,
+    reserved device names, trailing dots/spaces, length limits).
+  * Empty / unknown values degrade to a stable fallback ("Unknown Artist",
+    "Unknown Album", "Playlist - <service> - <id>") so a path is always valid.
+  * Duplicate destination names are made unique with a numeric suffix instead
+    of overwriting, so no file is ever silently clobbered.
+"""
+
+import posixpath
+import re
+
+# Characters Windows forbids in a path component. Backslash and forward slash
+# are included too so a value that happens to contain a separator can never
+# escape into a parent/child directory.
+_WINDOWS_FORBIDDEN = '<>:"/\\|?*'
+_FORBIDDEN_RE = re.compile('[' + re.escape(_WINDOWS_FORBIDDEN) + ']')
+
+# C0 control characters are illegal on Windows and hostile on Linux.
+_CONTROL_RE = re.compile(r'[\x00-\x1f\x7f]')
+
+# Collapse runs of whitespace so sanitised names stay tidy.
+_WS_RE = re.compile(r'\s+')
+
+# Windows reserved device names (matched case-insensitively on the stem).
+_WINDOWS_RESERVED = {
+    "con", "prn", "aux", "nul",
+    *(f"com{i}" for i in range(1, 10)),
+    *(f"lpt{i}" for i in range(1, 10)),
+}
+
+# Cap for a single path component. Kept well under the common 255-byte
+# per-component limit to leave room for a dedupe suffix and an extension, and
+# to stay safe on filesystems with tighter limits.
+DEFAULT_MAX_COMPONENT = 150
+
+# Inserted where a forbidden character is removed mid-name.
+_REPLACEMENT = " "
+
+# Fallbacks so a path component is never blank.
+FALLBACK_ARTIST = "Unknown Artist"
+FALLBACK_ALBUM = "Unknown Album"
+FALLBACK_NAME = "Unknown"
+PLAYLISTS_DIR = "Playlists"
+PLAYLIST_FILE = "playlist.m3u"
+
+# Audio extensions streamrip can produce (lower-case, with leading dot).
+AUDIO_EXTENSIONS = frozenset({
+    ".flac", ".mp3", ".m4a", ".aac", ".ogg", ".opus", ".oga",
+    ".wav", ".aiff", ".aif", ".alac", ".wma",
+})
+
+# Human container label per extension for the <Quality> folder.
+_CONTAINER_LABELS = {
+    ".flac": "FLAC",
+    ".mp3": "MP3",
+    ".m4a": "AAC",
+    ".aac": "AAC",
+    ".ogg": "OGG",
+    ".oga": "OGG",
+    ".opus": "OPUS",
+    ".wav": "WAV",
+    ".aiff": "AIFF",
+    ".aif": "AIFF",
+    ".alac": "ALAC",
+    ".wma": "WMA",
+}
+
+
+# ── Name sanitising ────────────────────────────────────────────────────────
+
+def _split_ext(name):
+    """Return ``(root, ext)`` where *ext* includes the dot, or ``("", "")``.
+
+    Only treats a short, separator-free trailing segment as an extension so
+    names like ``"Vol. 2"`` are not mistaken for a file extension.
+    """
+    dot = name.rfind(".")
+    if dot <= 0:
+        return name, ""
+    ext = name[dot:]
+    if 1 < len(ext) <= 11 and " " not in ext:
+        return name[:dot], ext
+    return name, ""
+
+
+def _truncate(text, max_length, keep_extension):
+    if keep_extension:
+        root, ext = _split_ext(text)
+        if ext:
+            keep = max(1, max_length - len(ext))
+            return root[:keep].strip(" .") + ext
+    return text[:max_length]
+
+
+def safe_filename(name, *, max_length=DEFAULT_MAX_COMPONENT,
+                  fallback=FALLBACK_NAME, keep_extension=False):
+    """Return *name* sanitised into a single filesystem-safe path component.
+
+    Safe on both Linux and Windows:
+      * removes path separators, the Windows-forbidden set ``<>:"/\\|?*`` and
+        control characters,
+      * collapses whitespace,
+      * strips leading/trailing dots and spaces (Windows silently trims them,
+        which would otherwise make a name not round-trip),
+      * avoids the Windows reserved device names (CON, NUL, COM1 …),
+      * truncates to *max_length* (preserving a file extension when
+        *keep_extension* is set),
+      * falls back to *fallback* when the result would be empty.
+
+    Never returns ``""`` and never contains a path separator, so the result
+    can always be joined safely into a path.
+    """
+    text = "" if name is None else str(name)
+    text = _CONTROL_RE.sub("", text)
+    text = _FORBIDDEN_RE.sub(_REPLACEMENT, text)
+    text = _WS_RE.sub(" ", text).strip().strip(" .").strip()
+    if not text:
+        return fallback
+
+    stem = text.split(".", 1)[0].strip().lower()
+    if stem in _WINDOWS_RESERVED:
+        text = "_" + text
+
+    if max_length and len(text) > max_length:
+        text = _truncate(text, max_length, keep_extension)
+
+    text = text.strip(" .")
+    return text or fallback
+
+
+def album_artist_folder(artist, *, max_length=DEFAULT_MAX_COMPONENT):
+    """Filesystem-safe folder name for an album artist.
+
+    Stable for a given artist so albums downloaded separately land side by
+    side under the same artist folder.
+    """
+    return safe_filename(artist, max_length=max_length, fallback=FALLBACK_ARTIST)
+
+
+def album_folder(title, *, max_length=DEFAULT_MAX_COMPONENT):
+    """Filesystem-safe folder name for an album title."""
+    return safe_filename(title, max_length=max_length, fallback=FALLBACK_ALBUM)
+
+
+def quality_folder(container, bit_depth=None, sampling_rate=None):
+    """Folder name describing the audio quality, e.g. ``FLAC (16B-44100kHz)``.
+
+    *container* is a human label (``"FLAC"``, ``"MP3"`` …). When both
+    *bit_depth* and *sampling_rate* are known they are appended; otherwise the
+    container alone is used (lossy formats have no meaningful bit depth).
+    """
+    label = safe_filename(container, fallback="Audio")
+    if bit_depth and sampling_rate:
+        return safe_filename(f"{label} ({bit_depth}B-{sampling_rate}kHz)",
+                             fallback=label)
+    return label
+
+
+def playlist_folder(name, *, service=None, playlist_id=None,
+                    max_length=DEFAULT_MAX_COMPONENT):
+    """Filesystem-safe folder name for a playlist.
+
+    Falls back to ``Playlist - <service> - <id>`` when the playlist name is
+    unavailable, so the destination is always valid and identifiable.
+    """
+    safe = safe_filename(name, max_length=max_length, fallback="")
+    if safe:
+        return safe
+    parts = ["Playlist"]
+    if service:
+        parts.append(str(service))
+    if playlist_id:
+        parts.append(str(playlist_id))
+    fallback = " - ".join(parts)
+    return safe_filename(fallback, max_length=max_length, fallback="Playlist")
+
+
+# ── Duplicate handling ─────────────────────────────────────────────────────
+
+def dedupe_filename(name, taken):
+    """Return a version of *name* not present in *taken* (case-insensitively).
+
+    *taken* is any iterable of names already in use. If *name* is free it is
+    returned unchanged; otherwise a numeric suffix is inserted before the
+    extension::
+
+        track.flac -> track (2).flac -> track (3).flac ...
+
+    Comparison is case-insensitive so the result is safe on case-insensitive
+    filesystems (Windows, default macOS). The caller is responsible for adding
+    the returned value to *taken* before the next call.
+    """
+    lowered = {str(t).lower() for t in taken}
+    if name.lower() not in lowered:
+        return name
+    root, ext = _split_ext(name)
+    n = 2
+    while True:
+        candidate = f"{root} ({n}){ext}"
+        if candidate.lower() not in lowered:
+            return candidate
+        n += 1
+
+
+# ── File-type helpers ──────────────────────────────────────────────────────
+
+def is_audio_file(name):
+    """True if *name* has a known audio extension."""
+    _, ext = _split_ext(str(name))
+    return ext.lower() in AUDIO_EXTENSIONS
+
+
+def container_label(ext):
+    """Human container label for a file extension (``.flac`` -> ``FLAC``)."""
+    e = (ext or "").lower()
+    if e and not e.startswith("."):
+        e = "." + e
+    return _CONTAINER_LABELS.get(e, e.lstrip(".").upper() or "Audio")
+
+
+def dominant_container(filenames):
+    """Most common audio container label among *filenames*, or ``""``.
+
+    Used to label the <Quality> folder from the files actually written, so the
+    label reflects reality even if the requested quality was downgraded.
+    """
+    counts = {}
+    for name in filenames:
+        if is_audio_file(name):
+            _, ext = _split_ext(str(name))
+            ext = ext.lower()
+            counts[ext] = counts.get(ext, 0) + 1
+    if not counts:
+        return ""
+    best = max(counts, key=lambda e: (counts[e], e))
+    return container_label(best)
+
+
+# ── m3u playlist body ──────────────────────────────────────────────────────
+
+def m3u_content(entries):
+    """Build a UTF-8 ``#EXTM3U`` playlist body from *entries*.
+
+    *entries* is an ordered iterable of either a path string or a
+    ``(path, title)`` / ``(path, title, seconds)`` tuple. Relative paths are
+    recommended so the playlist stays portable when the folder is moved.
+    """
+    lines = ["#EXTM3U"]
+    for entry in entries:
+        if isinstance(entry, (tuple, list)):
+            path = entry[0]
+            title = entry[1] if len(entry) > 1 else ""
+            seconds = entry[2] if len(entry) > 2 else -1
+        else:
+            path, title, seconds = entry, "", -1
+        if title:
+            try:
+                secs = int(seconds)
+            except (TypeError, ValueError):
+                secs = -1
+            lines.append(f"#EXTINF:{secs},{title}")
+        lines.append(str(path))
+    return "\n".join(lines) + "\n"
+
+
+# ── Move planning (pure) ───────────────────────────────────────────────────
+
+def _join(*parts):
+    return posixpath.join(*[p for p in parts if p])
+
+
+def plan_album_layout(filenames, *, album_artist, album_title, quality,
+                      existing=None):
+    """Plan where each album file should live under the library root.
+
+    *filenames* are the basenames streamrip produced for the album (tracks,
+    ``cover.jpg``, any sidecars). Returns a list of
+    ``(source_filename, destination_relpath)`` pairs, where the destination is::
+
+        <Album Artist>/<Album Title>/<Quality>/<filename>
+
+    relative to the download root (POSIX separators). Files keep their
+    streamrip-generated names — already ``"NN. Artist - Title.ext"`` and
+    ``cover.jpg`` — so track numbers, cover art and embedded metadata are
+    preserved untouched. Duplicate basenames (e.g. two discs each with a
+    "01. …") are made unique with a numeric suffix. *existing* may list names
+    already present in the destination so they are not overwritten.
+    """
+    base_dir = _join(album_artist_folder(album_artist),
+                     album_folder(album_title),
+                     safe_filename(quality, fallback="Audio"))
+    return _plan_into(filenames, base_dir, existing)
+
+
+def plan_playlist_layout(filenames, *, playlist_name, service=None,
+                         playlist_id=None, parent=PLAYLISTS_DIR, existing=None):
+    """Plan a playlist's flat layout under ``<parent>/<Playlist Name>/``.
+
+    Returns a dict with:
+      * ``folder``  — destination folder relpath under the library root,
+      * ``moves``   — list of ``(source_filename, destination_relpath)``,
+      * ``audio``   — destination basenames of audio tracks, in input order
+                      (used to build ``playlist.m3u``).
+
+    Input order is preserved so the playlist order is kept; the caller should
+    pass *filenames* already ordered (e.g. by streamrip's numeric prefix).
+    """
+    folder = playlist_folder(playlist_name, service=service,
+                             playlist_id=playlist_id)
+    base_dir = _join(parent, folder) if parent else folder
+    moves = _plan_into(filenames, base_dir, existing)
+    audio = [posixpath.basename(dst) for _, dst in moves
+             if is_audio_file(dst)]
+    return {"folder": base_dir, "moves": moves, "audio": audio}
+
+
+def _plan_into(filenames, base_dir, existing):
+    taken = {str(e).lower() for e in (existing or [])}
+    moves = []
+    for name in filenames:
+        dest_name = dedupe_filename(
+            safe_filename(name, keep_extension=True), taken)
+        taken.add(dest_name.lower())
+        moves.append((name, _join(base_dir, dest_name)))
+    return moves

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1,0 +1,276 @@
+"""Tests for the library-organisation helpers in ``core.library``.
+
+These cover the pure, GTK-free layer that backs Auryn's post-download
+reorganisation into a NAS / Jellyfin / Symfonium-friendly structure:
+filesystem-safe names (Linux + Windows), album/playlist path generation,
+duplicate filename handling and the multiple-albums-per-artist guarantee.
+No file I/O happens here — only name/path computation is exercised.
+"""
+
+from core import library
+
+
+# ── Safe filename generation ───────────────────────────────────────────────
+
+def test_safe_filename_basic_passthrough():
+    assert library.safe_filename("Daft Punk") == "Daft Punk"
+    assert library.safe_filename("Discovery") == "Discovery"
+
+
+def test_safe_filename_empty_uses_fallback():
+    assert library.safe_filename("") == library.FALLBACK_NAME
+    assert library.safe_filename(None) == library.FALLBACK_NAME
+    assert library.safe_filename("   ") == library.FALLBACK_NAME
+    assert library.safe_filename("", fallback="X") == "X"
+
+
+def test_safe_filename_collapses_whitespace():
+    assert library.safe_filename("A   B\t C") == "A B C"
+
+
+def test_safe_filename_never_contains_separator():
+    out = library.safe_filename("AC/DC")
+    assert "/" not in out and "\\" not in out
+    out2 = library.safe_filename("a\\b/c")
+    assert "/" not in out2 and "\\" not in out2
+
+
+# ── Windows-invalid characters and quirks ──────────────────────────────────
+
+def test_windows_forbidden_characters_removed():
+    # < > : " / \ | ? * are all illegal in a Windows path component.
+    out = library.safe_filename('a<b>c:d"e/f\\g|h?i*j')
+    for ch in '<>:"/\\|?*':
+        assert ch not in out
+
+
+def test_windows_trailing_dots_and_spaces_stripped():
+    # Windows silently trims trailing dots/spaces; we must do so explicitly.
+    assert library.safe_filename("name.") == "name"
+    assert library.safe_filename("name ") == "name"
+    assert library.safe_filename("name. . .") == "name"
+    assert library.safe_filename("  spaced  ") == "spaced"
+
+
+def test_windows_reserved_device_names_are_escaped():
+    assert library.safe_filename("CON") != "CON"
+    assert library.safe_filename("con").lower() != "con"
+    assert library.safe_filename("NUL").endswith("NUL")
+    assert library.safe_filename("COM1") != "COM1"
+    # Reserved name with an extension is still reserved on Windows.
+    assert library.safe_filename("con.flac") != "con.flac"
+    # A normal name that merely contains a reserved substring is untouched.
+    assert library.safe_filename("Control") == "Control"
+
+
+def test_control_characters_removed():
+    out = library.safe_filename("a\x00b\x1fc\x7fd")
+    assert out == "abcd"
+
+
+def test_long_names_truncated_gracefully():
+    long = "x" * 500
+    out = library.safe_filename(long)
+    assert len(out) <= library.DEFAULT_MAX_COMPONENT
+    assert out  # never empty
+
+
+def test_long_filename_preserves_extension():
+    long = "y" * 500 + ".flac"
+    out = library.safe_filename(long, keep_extension=True)
+    assert len(out) <= library.DEFAULT_MAX_COMPONENT
+    assert out.endswith(".flac")
+
+
+def test_dotted_album_title_not_treated_as_extension():
+    # A short title with internal dots must survive intact (no truncation).
+    assert library.safe_filename("Vol. 2") == "Vol. 2"
+    assert library.safe_filename("M.A.C.H") == "M.A.C.H"
+
+
+# ── Album path generation ──────────────────────────────────────────────────
+
+def test_album_artist_and_album_folders():
+    assert library.album_artist_folder("Avenged Sevenfold") == "Avenged Sevenfold"
+    assert library.album_folder("Nightmare") == "Nightmare"
+
+
+def test_album_folder_fallbacks():
+    assert library.album_artist_folder("") == library.FALLBACK_ARTIST
+    assert library.album_folder("") == library.FALLBACK_ALBUM
+
+
+def test_quality_folder_with_and_without_specs():
+    assert library.quality_folder("FLAC", 16, 44100) == "FLAC (16B-44100kHz)"
+    assert library.quality_folder("FLAC", 24, 96000) == "FLAC (24B-96000kHz)"
+    assert library.quality_folder("MP3") == "MP3"
+    # Lossy formats: no bit depth even if a sample rate is somehow supplied.
+    assert library.quality_folder("MP3", None, 44100) == "MP3"
+
+
+def test_plan_album_layout_matches_desired_structure():
+    files = ["01. Avenged Sevenfold - Nightmare.flac", "cover.jpg"]
+    moves = library.plan_album_layout(
+        files,
+        album_artist="Avenged Sevenfold",
+        album_title="Nightmare",
+        quality="FLAC (16B-44100kHz)",
+    )
+    dests = dict(moves)
+    assert dests["01. Avenged Sevenfold - Nightmare.flac"] == (
+        "Avenged Sevenfold/Nightmare/FLAC (16B-44100kHz)/"
+        "01. Avenged Sevenfold - Nightmare.flac"
+    )
+    # cover.jpg is preserved and relocated alongside the tracks.
+    assert dests["cover.jpg"] == (
+        "Avenged Sevenfold/Nightmare/FLAC (16B-44100kHz)/cover.jpg"
+    )
+
+
+def test_album_track_numbers_preserved_in_destination():
+    files = [f"{n:02d}. Artist - Track {n}.flac" for n in range(1, 4)]
+    moves = library.plan_album_layout(
+        files, album_artist="Artist", album_title="Album",
+        quality="FLAC (16B-44100kHz)")
+    for src, dst in moves:
+        assert dst.endswith(src)  # name (with NN. prefix) unchanged
+
+
+# ── Multiple albums from the same artist sit side by side ──────────────────
+
+def test_multiple_albums_same_artist_share_artist_folder():
+    a = library.plan_album_layout(
+        ["01. Avenged Sevenfold - Nightmare.flac"],
+        album_artist="Avenged Sevenfold", album_title="Nightmare",
+        quality="FLAC (16B-44100kHz)")
+    b = library.plan_album_layout(
+        ["01. Avenged Sevenfold - Shepherd of Fire.flac"],
+        album_artist="Avenged Sevenfold", album_title="Hail to the King",
+        quality="FLAC (16B-44100kHz)")
+    artist_a = a[0][1].split("/")[0]
+    artist_b = b[0][1].split("/")[0]
+    assert artist_a == artist_b == "Avenged Sevenfold"
+    # ...but the album folders differ, so they are siblings, not nested.
+    assert a[0][1].split("/")[1] == "Nightmare"
+    assert b[0][1].split("/")[1] == "Hail to the King"
+
+
+# ── Duplicate filename handling ────────────────────────────────────────────
+
+def test_dedupe_filename_first_use_unchanged():
+    assert library.dedupe_filename("track.flac", set()) == "track.flac"
+
+
+def test_dedupe_filename_appends_numeric_suffix():
+    taken = {"track.flac"}
+    out = library.dedupe_filename("track.flac", taken)
+    assert out == "track (2).flac"
+    taken.add(out.lower())
+    assert library.dedupe_filename("track.flac", taken) == "track (3).flac"
+
+
+def test_dedupe_filename_case_insensitive():
+    assert library.dedupe_filename("Track.FLAC", {"track.flac"}) == "Track (2).FLAC"
+
+
+def test_dedupe_filename_no_extension():
+    assert library.dedupe_filename("cover", {"cover"}) == "cover (2)"
+
+
+def test_plan_album_layout_dedupes_duplicate_basenames():
+    # Two discs each contributing a "01." track must not collide.
+    files = ["01. Artist - Intro.flac", "01. Artist - Intro.flac"]
+    moves = library.plan_album_layout(
+        files, album_artist="Artist", album_title="Album",
+        quality="FLAC (16B-44100kHz)")
+    dests = [d for _, d in moves]
+    assert len(set(dests)) == len(dests)  # all unique
+
+
+def test_plan_album_layout_respects_existing_names():
+    moves = library.plan_album_layout(
+        ["01. Artist - Song.flac"],
+        album_artist="Artist", album_title="Album",
+        quality="FLAC (16B-44100kHz)",
+        existing=["01. Artist - Song.flac"])
+    assert moves[0][1].endswith("01. Artist - Song (2).flac")
+
+
+# ── Playlist path generation ───────────────────────────────────────────────
+
+def test_playlist_folder_basic():
+    assert library.playlist_folder("My Roadtrip Mix") == "My Roadtrip Mix"
+
+
+def test_playlist_folder_fallback_when_name_missing():
+    out = library.playlist_folder("", service="deezer", playlist_id="12345")
+    assert out == "Playlist - deezer - 12345"
+    # No service/id available still yields a valid, identifiable folder.
+    assert library.playlist_folder(None) == "Playlist"
+
+
+def test_plan_playlist_layout_uses_playlists_parent():
+    files = ["01. A - One.flac", "02. B - Two.flac", "cover.jpg"]
+    plan = library.plan_playlist_layout(files, playlist_name="Summer Hits")
+    assert plan["folder"] == "Playlists/Summer Hits"
+    for _, dst in plan["moves"]:
+        assert dst.startswith("Playlists/Summer Hits/")
+
+
+def test_plan_playlist_layout_preserves_order_and_lists_audio():
+    files = ["01. A - One.flac", "02. B - Two.flac", "cover.jpg", "notes.txt"]
+    plan = library.plan_playlist_layout(files, playlist_name="Mix")
+    # Audio entries kept in input order; non-audio excluded from m3u list.
+    assert plan["audio"] == ["01. A - One.flac", "02. B - Two.flac"]
+
+
+def test_plan_playlist_layout_custom_parent():
+    plan = library.plan_playlist_layout(
+        ["01. A - One.flac"], playlist_name="Mix", parent="")
+    assert plan["folder"] == "Mix"
+
+
+def test_plan_playlist_dedupes_within_folder():
+    files = ["01. A - One.flac", "01. A - One.flac"]
+    plan = library.plan_playlist_layout(files, playlist_name="Mix")
+    dests = [d for _, d in plan["moves"]]
+    assert len(set(dests)) == 2
+
+
+# ── Container / quality detection ──────────────────────────────────────────
+
+def test_is_audio_file():
+    assert library.is_audio_file("01. Artist - Song.flac")
+    assert library.is_audio_file("song.MP3")
+    assert not library.is_audio_file("cover.jpg")
+    assert not library.is_audio_file("playlist.m3u")
+
+
+def test_container_label():
+    assert library.container_label(".flac") == "FLAC"
+    assert library.container_label("mp3") == "MP3"
+    assert library.container_label(".m4a") == "AAC"
+    assert library.container_label(".weird") == "WEIRD"
+
+
+def test_dominant_container():
+    assert library.dominant_container(
+        ["a.flac", "b.flac", "cover.jpg"]) == "FLAC"
+    assert library.dominant_container(["a.mp3", "b.mp3"]) == "MP3"
+    assert library.dominant_container(["cover.jpg"]) == ""
+
+
+# ── m3u body ───────────────────────────────────────────────────────────────
+
+def test_m3u_content_plain_paths():
+    body = library.m3u_content(["01. A - One.flac", "02. B - Two.flac"])
+    assert body.startswith("#EXTM3U\n")
+    assert "01. A - One.flac" in body
+    assert "02. B - Two.flac" in body
+    assert body.endswith("\n")
+
+
+def test_m3u_content_with_extinf():
+    body = library.m3u_content([("01. A - One.flac", "A - One", 215)])
+    assert "#EXTINF:215,A - One" in body
+    assert "01. A - One.flac" in body

--- a/tests/test_organize_integration.py
+++ b/tests/test_organize_integration.py
@@ -1,0 +1,262 @@
+"""Integration tests for post-download library organisation.
+
+These drive the *real* ``AurynApp`` organisation methods against temporary
+directories laid out exactly as streamrip leaves them, so the behaviour the
+PR test-plan describes is verified end to end (minus the network download and
+GTK rendering, which cannot run headlessly). The streamrip download itself is
+never invoked — we only feed in the files it would have produced and check
+that they are relocated into the expected library tree.
+
+The GTK application module imports cleanly without a display because GTK is
+imported lazily (see ``Auryn._import_gtk``); if that ever changes these tests
+skip rather than fail the suite.
+"""
+
+import inspect
+import os
+import types
+
+import pytest
+
+try:
+    import Auryn
+except Exception as exc:  # pragma: no cover - defensive: never break the suite
+    pytest.skip(f"Auryn module unavailable: {exc}", allow_module_level=True)
+
+from core import metadata
+
+App = Auryn.AurynApp
+
+# Methods copied onto the fake ``self`` so the real implementations run.
+_ORG_METHODS = (
+    "_organize_download", "_organize_album", "_organize_playlist",
+    "_quality_folder_label", "_collect_files", "_sort_playlist_files",
+    "_playlist_name", "_playlist_id", "_execute_moves",
+    "_write_playlist_m3u", "_cleanup_empty_dirs", "_remember_album_meta",
+)
+
+
+def _app(base, *, is_playlist=False, album_meta=None,
+         url="https://www.deezer.com/en/album/123", quality="2",
+         organize=True, playlists_subfolder=True):
+    """A GTK-free stand-in carrying the real organisation methods."""
+    s = types.SimpleNamespace()
+    s.logs = []
+    s._log = lambda text="", tag=None: s.logs.append(text)
+    s._config = {"organize_library": organize,
+                 "playlists_subfolder": playlists_subfolder}
+    s._dest_folder = base
+    s._active_url = url
+    s._active_quality = quality
+    s._active_is_playlist = is_playlist
+    s._album_meta = album_meta
+    s._FLAC_QUALITY_SPECS = App._FLAC_QUALITY_SPECS
+    for name in _ORG_METHODS:
+        raw = inspect.getattr_static(App, name)
+        if isinstance(raw, staticmethod):
+            setattr(s, name, getattr(App, name))
+        else:
+            setattr(s, name, getattr(App, name).__get__(s, App))
+    return s
+
+
+def _tree(base):
+    out = []
+    for root, _dirs, files in os.walk(base):
+        for f in files:
+            out.append(os.path.relpath(os.path.join(root, f), base).replace(os.sep, "/"))
+    return sorted(out)
+
+
+def _touch(path, content="x"):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as fh:
+        fh.write(content)
+
+
+# ── Test-plan item 1: Deezer album layout ──────────────────────────────────
+
+def test_plan1_deezer_album_layout(tmp_path):
+    base = str(tmp_path)
+    src = os.path.join(base, "Avenged Sevenfold - Nightmare (2010) [FLAC]")
+    _touch(os.path.join(src, "01. Avenged Sevenfold - Nightmare.flac"))
+    _touch(os.path.join(src, "02. Avenged Sevenfold - So Far Away.flac"))
+    _touch(os.path.join(src, "cover.jpg"))
+
+    s = _app(base, album_meta={"artist": "Avenged Sevenfold",
+                               "album": "Nightmare"})
+    result = s._organize_download(src)
+
+    t = _tree(base)
+    qdir = "Avenged Sevenfold/Nightmare/FLAC (16B-44100kHz)"
+    assert f"{qdir}/01. Avenged Sevenfold - Nightmare.flac" in t
+    assert f"{qdir}/02. Avenged Sevenfold - So Far Away.flac" in t
+    assert f"{qdir}/cover.jpg" in t            # cover preserved
+    assert not os.path.exists(src)             # streamrip folder cleaned up
+    assert result == os.path.join(base, "Avenged Sevenfold", "Nightmare")
+
+
+# ── Test-plan item 2: multiple albums, same artist, side by side ───────────
+
+def test_plan2_multiple_albums_same_artist(tmp_path):
+    base = str(tmp_path)
+
+    a = os.path.join(base, "AVS - Nightmare [FLAC]")
+    _touch(os.path.join(a, "01. Avenged Sevenfold - Nightmare.flac"))
+    _app(base, album_meta={"artist": "Avenged Sevenfold",
+                           "album": "Nightmare"})._organize_download(a)
+
+    b = os.path.join(base, "AVS - Hail to the King [FLAC]")
+    _touch(os.path.join(b, "01. Avenged Sevenfold - Shepherd of Fire.flac"))
+    _app(base, album_meta={"artist": "Avenged Sevenfold",
+                           "album": "Hail to the King"})._organize_download(b)
+
+    t = _tree(base)
+    assert any(p.startswith("Avenged Sevenfold/Nightmare/") for p in t)
+    assert any(p.startswith("Avenged Sevenfold/Hail to the King/") for p in t)
+    # Exactly one artist folder at the top level (the two albums are siblings).
+    top = {p.split("/")[0] for p in t}
+    assert top == {"Avenged Sevenfold"}
+
+
+# ── Test-plan item 3: playlist layout, m3u and order ───────────────────────
+
+def test_plan3_playlist_layout_and_m3u(tmp_path):
+    base = str(tmp_path)
+    src = os.path.join(base, "My Roadtrip Mix")
+    # Deliberately created out of order; organisation must sort by track no.
+    _touch(os.path.join(src, "02. B Band - Second.flac"))
+    _touch(os.path.join(src, "01. A Band - First.flac"))
+    _touch(os.path.join(src, "03. C Band - Third.flac"))
+    _touch(os.path.join(src, "cover.jpg"))
+
+    s = _app(base, is_playlist=True,
+             url="https://www.deezer.com/en/playlist/789")
+    result = s._organize_download(src)
+
+    t = _tree(base)
+    pdir = "Playlists/My Roadtrip Mix"
+    assert f"{pdir}/01. A Band - First.flac" in t
+    assert f"{pdir}/02. B Band - Second.flac" in t
+    assert f"{pdir}/03. C Band - Third.flac" in t
+    assert f"{pdir}/cover.jpg" in t             # cover preserved
+    assert f"{pdir}/playlist.m3u" in t          # m3u generated
+    assert result == os.path.join(base, "Playlists", "My Roadtrip Mix")
+
+    with open(os.path.join(base, pdir, "playlist.m3u")) as fh:
+        m3u = fh.read()
+    assert m3u.startswith("#EXTM3U")
+    # Order preserved, cover excluded from the playlist body.
+    assert m3u.index("01. A Band - First.flac") < m3u.index("02. B Band - Second.flac")
+    assert m3u.index("02. B Band - Second.flac") < m3u.index("03. C Band - Third.flac")
+    assert "cover.jpg" not in m3u
+
+
+def test_plan3_playlist_name_fallback(tmp_path):
+    base = str(tmp_path)
+    # streamrip could not name the folder after the playlist.
+    src = os.path.join(base, "")  # not usable; emulate via a blank-ish name
+    src = os.path.join(base, " ")
+    _touch(os.path.join(src, "01. A - One.flac"))
+    s = _app(base, is_playlist=True,
+             url="https://www.deezer.com/en/playlist/55555")
+    result = s._organize_download(src)
+    # Falls back to "Playlist - <service> - <id>".
+    assert os.path.basename(result) == "Playlist - deezer - 55555"
+
+
+# ── Test-plan item 4: settings toggles ─────────────────────────────────────
+
+def test_plan4_organize_disabled_leaves_files(tmp_path):
+    base = str(tmp_path)
+    src = os.path.join(base, "Artist - Album [FLAC]")
+    _touch(os.path.join(src, "01. Artist - Song.flac"))
+    s = _app(base, album_meta={"artist": "Artist", "album": "Album"},
+             organize=False)
+    result = s._organize_download(src)
+    assert "Artist - Album [FLAC]/01. Artist - Song.flac" in _tree(base)
+    assert result == src
+
+
+def test_plan4_playlists_subfolder_disabled_stays_flat(tmp_path):
+    base = str(tmp_path)
+    src = os.path.join(base, "Flat Mix")
+    _touch(os.path.join(src, "01. A - One.flac"))
+    s = _app(base, is_playlist=True, playlists_subfolder=False,
+             url="https://www.deezer.com/en/playlist/1")
+    s._organize_download(src)
+    t = _tree(base)
+    assert "Flat Mix/01. A - One.flac" in t
+    assert not any(p.startswith("Playlists/") for p in t)
+
+
+# ── Test-plan item 5: Qobuz path + metadata sidebar unaffected ─────────────
+
+def test_plan5_qobuz_hires_album_layout(tmp_path):
+    base = str(tmp_path)
+    src = os.path.join(base, "Air - Moon Safari [FLAC]")
+    _touch(os.path.join(src, "01. Air - La Femme d'Argent.flac"))
+    _touch(os.path.join(src, "cover.jpg"))
+    s = _app(base, album_meta={"artist": "Air", "album": "Moon Safari"},
+             url="https://open.qobuz.com/album/abc123", quality="3")
+    s._organize_download(src)
+    t = _tree(base)
+    # Qobuz hi-res FLAC (quality 3) -> 24-bit / 96 kHz quality folder.
+    assert "Air/Moon Safari/FLAC (24B-96000kHz)/01. Air - La Femme d'Argent.flac" in t
+    assert "Air/Moon Safari/FLAC (24B-96000kHz)/cover.jpg" in t
+
+
+def test_plan5_metadata_sidebar_parsing_unaffected(tmp_path):
+    # The sidebar parsing layer (core.metadata) is unchanged: it still yields
+    # the expected fields, and the new _remember_album_meta only *reads* them.
+    deezer_fields = metadata.deezer_album_fields(
+        {"artist": {"name": "Daft Punk"}, "title": "Discovery"})
+    qobuz_fields = metadata.qobuz_album_fields(
+        {"artist": {"name": "Air"}, "title": "Moon Safari"})
+    assert deezer_fields["artist"] == "Daft Punk"
+    assert qobuz_fields["album"] == "Moon Safari"
+
+    s = _app(str(tmp_path))
+    before = dict(qobuz_fields)
+    s._remember_album_meta(qobuz_fields)
+    assert s._album_meta == {"artist": "Air", "album": "Moon Safari"}
+    assert qobuz_fields == before  # input payload not mutated
+
+
+def test_plan5_remember_album_meta_tolerates_bad_payload(tmp_path):
+    s = _app(str(tmp_path))
+    for bad in (None, [], "oops", 42, {}):
+        s._album_meta = None
+        s._remember_album_meta(bad)  # must not raise
+        assert s._album_meta is None
+
+
+# ── Safety: failure leaves files in place with the required warning ────────
+
+def test_failure_leaves_files_and_warns(tmp_path, monkeypatch):
+    base = str(tmp_path)
+    src = os.path.join(base, "Artist - Album [FLAC]")
+    _touch(os.path.join(src, "01. Artist - Song.flac"))
+    s = _app(base, album_meta={"artist": "Artist", "album": "Album"})
+
+    def boom(*_a, **_k):
+        raise OSError("disk full")
+    monkeypatch.setattr(Auryn.shutil, "move", boom)
+
+    result = s._organize_download(src)
+    assert result == src
+    assert os.path.exists(os.path.join(src, "01. Artist - Song.flac"))
+    assert any("library organization failed" in str(m) for m in s.logs)
+
+
+def test_redownload_same_content_is_idempotent(tmp_path):
+    base = str(tmp_path)
+    src = os.path.join(base, "Artist - Album [FLAC]")
+    _touch(os.path.join(src, "01. Artist - Song.flac"))
+    s = _app(base, album_meta={"artist": "Artist", "album": "Album"})
+    first = s._organize_download(src)
+    tree1 = _tree(base)
+    # Re-run organisation pointing at the already-organised folder.
+    s._organize_download(first)
+    assert _tree(base) == tree1
+    assert sum(1 for p in _tree(base) if p.endswith(".flac")) == 1


### PR DESCRIPTION
## Summary

After a download finishes, Auryn now reorganises the files into a predictable, NAS / Jellyfin / Symfonium-friendly library tree. This is **pure post-processing** layered on top of streamrip — the download pipeline itself is untouched.

The work lives in a new GTK-free helper module (`src/core/library.py`) plus a thin execution layer in `Auryn.py` that only runs after a download has finished. Two default-on settings let users opt out.

## Album organization behavior

- Albums are grouped under the **album artist**, then album title, then a **quality** subfolder.
- Multiple albums by the same artist land **side by side** under one artist folder (the artist folder name is stable, so separate downloads accumulate next to each other).
- streamrip's track names (`NN. Artist - Title.ext`), **track numbers**, embedded tags and `cover.jpg` are preserved untouched (files are relocated, never rewritten).
- The quality folder is labelled from the files actually written: lossless FLAC gets `FLAC (16B-44100kHz)` etc.; lossy formats get a container-only label (`MP3`).

```
Music/
  Avenged Sevenfold/
    Nightmare/
      FLAC (16B-44100kHz)/
        01. Avenged Sevenfold - Nightmare.flac
        02. Avenged Sevenfold - Welcome to the Family.flac
        cover.jpg
    Hail to the King/
      FLAC (16B-44100kHz)/
        01. Avenged Sevenfold - Shepherd of Fire.flac
        cover.jpg
```

## Playlist organization behavior

- Playlists go under a dedicated `Playlists/` folder (toggleable).
- Track order is preserved (ordered by streamrip's numeric prefix) and a `playlist.m3u` is generated.
- `cover.jpg` is preserved; duplicate track filenames are de-conflicted with a numeric suffix.
- If the playlist name is unavailable, a safe fallback `Playlist - <service> - <id>` is used.

```
Music/
  Playlists/
    My Roadtrip Mix/
      01. A - One.flac
      02. B - Two.flac
      playlist.m3u
      cover.jpg
```

## Safety

- Runs **only** after a successful or partial download (files are no longer being written) — no risky moves during an active download.
- **Never overwrites a different file**: same-name + same-size is treated as identical (idempotent re-downloads); otherwise a unique name is chosen.
- Filesystem-safe names on Linux **and** Windows: forbidden characters `<>:"/\|?*`, reserved device names (`CON`, `NUL`, `COM1`…), trailing dots/spaces and over-long names are all handled.
- On **any** failure, no files are deleted and the log shows: *"Download finished, but library organization failed — files were left in the original output folder."*
- If album metadata isn't available, organisation is skipped quietly and the files are left where streamrip wrote them.

## Settings

- **Organize downloads for music libraries** — enabled by default.
- **Put playlists in a Playlists folder** — enabled by default.

## Download logic was NOT rewritten

The streamrip invocation, config writing, quality clamping, Deezer/Qobuz URL handling and the right-side cover/metadata sidebar are all unchanged. The new behaviour is additive post-processing that hooks into the existing success/partial finish handlers and can be turned off entirely.

## Validation

- `python3 -m py_compile src/Auryn.py src/core/library.py` — passes.
- `pytest` — **158 passed** (34 new tests in `tests/test_library.py` covering safe filename generation, album/playlist path generation, duplicate handling, Windows-invalid characters, and the multiple-albums-same-artist behavior).
- `flake8 --select=E9,F63,F7,F82` (the blocking CI lint) — clean on all changed files; new files are also style-clean at `--max-line-length=127`.
- End-to-end: exercised the real organization methods against temp directories — album tree, multiple-albums-same-artist, playlist + m3u + ordering, the `Playlists/` toggle, dedup across discs, idempotent re-runs, the disabled-setting path, missing-metadata skip, Qobuz hi-res (`24B-96000kHz`) and MP3 (container-only) labels, and the failure path (files preserved + warning shown). All scenarios produced the expected structure.

> Note: the GTK UI could not be launched in this headless environment; behaviour was validated via the pure helpers, the real organization methods driven against temp folders, and XML well-formedness of `Auryn.ui`.

## Test plan

- [ ] Download a Deezer album → verify `Artist/Album/FLAC (16B-44100kHz)/` with `cover.jpg` and numbered tracks.
- [ ] Download a second album by the same artist → verify both sit side by side under one artist folder.
- [ ] Download a playlist → verify `Playlists/<name>/` with `playlist.m3u` and preserved order.
- [ ] Toggle each setting off → verify behaviour reverts / playlists stay flat.
- [ ] Confirm the Qobuz path and the metadata/cover sidebar are unaffected.

https://claude.ai/code/session_017NNAgrn5PVRkC5yL1cfqWV

---
_Generated by [Claude Code](https://claude.ai/code/session_017NNAgrn5PVRkC5yL1cfqWV)_