### PR TITLE
Use dark charcoal text on the teal accent for readability

### DIFF
--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -59,7 +59,8 @@ def _import_gtk():
 
 
 CSS = b"""
-/* Auryn dark theme -- black canvas, orange (#14B8A6) accent. */
+/* Auryn dark theme -- black canvas, teal (#14B8A6) accent.
+   Text on the bright teal accent is dark charcoal (#0a0a0a) for strong contrast. */
 * { font-family: 'Inter', 'Ubuntu', 'Cantarell', sans-serif; }
 window { background-color: #161616; color: #e8e8e8; }
 
@@ -80,20 +81,20 @@ window { background-color: #161616; color: #e8e8e8; }
 #quality_box { background-color: #121212; border: 1px solid #242424; border-radius: 9px; padding: 5px 6px; }
 #quality_box button { background-image: none; background-color: transparent; box-shadow: none; color: #b2b2b2; font-size: 12px; padding: 5px 13px; border-radius: 6px; border: 1px solid transparent; transition: all 120ms ease; }
 #quality_box button:hover { color: #ffffff; background-color: #1e1e1e; }
-#quality_box button:checked { background-image: none; box-shadow: none; background-color: #14B8A6; color: #ffffff; font-weight: bold; }
-#quality_box button:checked label { color: #ffffff; }
+#quality_box button:checked { background-image: none; box-shadow: none; background-color: #14B8A6; color: #0a0a0a; font-weight: bold; }
+#quality_box button:checked label { color: #0a0a0a; }
 
 /* -- Plain checkboxes (cache / organise / playlists toggles) -- */
 checkbutton { color: #a8a8a8; font-size: 12px; }
 checkbutton check { background-image: none; background-color: #0c0c0c; border: 1px solid #444; border-radius: 4px; min-width: 15px; min-height: 15px; margin-right: 5px; transition: all 120ms ease; }
-checkbutton:checked check { background-image: none; background-color: #14B8A6; border-color: #14B8A6; }
+checkbutton:checked check { background-image: none; background-color: #14B8A6; border-color: #14B8A6; color: #0a0a0a; }
 checkbutton label:hover { color: #14B8A6; }
 
 /* -- Buttons: secondary / primary / accent / destructive -- */
 .neutral-btn { background-image: none; background-color: #1e1e1e; color: #bdbdbd; border: 1px solid #2e2e2e; border-radius: 7px; padding: 6px 13px; font-size: 11px; transition: all 120ms ease; }
 .neutral-btn:hover { background-color: #262626; color: #ffffff; border-color: #14B8A6; }
 .neutral-btn:active { background-color: #2e2e2e; }
-#btn_download { background-image: none; background-color: #14B8A6; color: #ffffff; border: none; border-radius: 7px; padding: 9px 20px; font-size: 13px; font-weight: bold; box-shadow: 0 1px 5px rgba(20, 184, 166, 0.32); transition: background-color 120ms ease; }
+#btn_download { background-image: none; background-color: #14B8A6; color: #0a0a0a; border: none; border-radius: 7px; padding: 9px 20px; font-size: 13px; font-weight: bold; box-shadow: 0 1px 5px rgba(20, 184, 166, 0.32); transition: background-color 120ms ease; }
 #btn_download:hover { background-color: #1FC8B7; }
 #btn_download:active { background-color: #0F9D8F; }
 #btn_download:disabled { background-color: #2a2a2a; color: #5e5e5e; box-shadow: none; }


### PR DESCRIPTION
## Summary

UI polish for stronger contrast on the teal accent (`#14B8A6`). White text on the bright teal only reached **~2.49:1** contrast (below WCAG AA's 4.5:1). This switches the text/glyphs on bright teal backgrounds to dark charcoal (`#0a0a0a`), raising contrast to **~7.95:1 (AAA)** for a cleaner, more premium, more readable look.

Changed (all in the embedded CSS in `src/Auryn.py`):
- **Start Download** button (`#btn_download`) — white → dark charcoal text
- **Selected quality pill** (`#quality_box button:checked`) — white → dark charcoal text
- **Checked checkbox glyph** (`checkbutton:checked check`) — dark charcoal mark on the teal fill
- Fixed a stale code comment that called the accent "orange" (it's teal)

Intentionally left unchanged:
- The **teal accent color itself** — only the foreground text on it changed.
- **Download behavior** — this is a CSS-only change; no logic touched.
- **Stop** button (red `#c0392b`) — destructive color, not the teal accent; white text already reads well.
- **Add to Queue** ghost button, notebook tabs, and status badges — these are teal *text on dark* backgrounds, which are already high-contrast and readable.

## Contrast

| Element | Before | After |
|---|---|---|
| Text on teal `#14B8A6` | `#ffffff` — 2.49:1 (fails AA) | `#0a0a0a` — 7.95:1 (passes AAA) |

## Test plan
- [x] `python3 -m py_compile src/Auryn.py` passes; CSS braces balanced (45 rules)
- [x] Full test suite green (`169 passed`)
- [ ] Visual check in the running GTK app (couldn't be done in the headless CI container — verified instead via a faithful before/after mockup using the exact colors)

https://claude.ai/code/session_01EmwP3hkuL7FMLLCd31Dc7k

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmwP3hkuL7FMLLCd31Dc7k)_