### PR TITLE
Add a clean structured download progress view

### DIFF
--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -28,6 +28,7 @@ from core import tidal_auth
 from core import metadata
 from core import streamrip_status
 from core import log_format
+from core import download_session as dsession
 from core import deezer
 from core import library
 from core import quality as qual
@@ -125,6 +126,18 @@ progressbar progress { background-image: none; background-color: #14B8A6; border
 separator { background-color: #242424; min-width: 1px; min-height: 1px; }
 .history-row { background-color: #101010; border: 1px solid #1f1f1f; border-radius: 7px; padding: 2px; }
 .history-row:hover { border-color: #333; background-color: #141414; }
+
+/* -- Structured download progress view -- */
+#progress_summary { padding: 2px 2px 4px 2px; }
+.progress-head { padding: 2px 12px 6px 12px; }
+.progress-head label { color: #666666; }
+.progress-row { background-color: #101010; border: 1px solid #1f1f1f; border-radius: 7px; padding: 2px; }
+.progress-row:hover { border-color: #2c2c2c; background-color: #141414; }
+.track-bar trough { background-color: #0c0c0c; border: 1px solid #242424; border-radius: 3px; min-height: 5px; }
+.track-bar progress { background-image: none; background-color: #14B8A6; border-radius: 3px; min-height: 5px; }
+.track-bar.bar-done progress { background-color: #87a556; }
+.track-bar.bar-error progress { background-color: #e74c3c; }
+.track-bar.bar-skip progress { background-color: #5a5a5a; }
 """
 
 # Sourced from core.quality so the picker, the clamping rules and the log
@@ -505,6 +518,12 @@ class AurynApp:
         self._album_meta            = None
         self._active_is_playlist    = False
         self._active_quality        = None
+        # Structured per-track progress view (purely observational; never
+        # touches the streamrip download pipeline). The raw log lives on its
+        # own tab and stays the source of truth for debugging.
+        self._dl_session            = None
+        self._progress_rows         = []
+        self._progress_pulse_timer  = None
 
         # ── Forcer can-focus sur les widgets interactifs ──
         self.url_entry.set_can_focus(True)
@@ -571,8 +590,12 @@ class AurynApp:
         # ── Restaurer les préférences enregistrées ──
         self._apply_saved_preferences()
 
+        # ── Vue de progression structurée (onglet par défaut) ──
+        self._build_progress_tab()
+
         # ── Afficher ──
         self.window.show_all()
+        self._progress_reset()
         self.btn_stop.hide()
         self._is_first_launch = is_first_launch()
         if self._is_first_launch:
@@ -1059,6 +1082,10 @@ class AurynApp:
         self._active_is_playlist  = url_is_playlist(url)
         self._active_quality      = None
         self._reset_streamrip_signals()
+        self._dl_session          = dsession.DownloadSession()
+        self._progress_reset()
+        self._progress_refresh_summary()
+        self.notebook.set_current_page(0)
         self._set_status("⏳  Fetching album info...", "info")
         self._set_lyrics('<span foreground="#555555"><i>Lyrics appear here once a track is identified.</i></span>')
         quality = self._get_quality()
@@ -1086,11 +1113,15 @@ class AurynApp:
             data = fetch_qobuz_meta(item_id)
             if data and not data.get("status") == "error":
                 GLib.idle_add(self._apply_qobuz_meta, data)
+                GLib.idle_add(self._progress_init_tracks,
+                              metadata.qobuz_album_tracks(data))
         elif service == "deezer" and item_id:
             GLib.idle_add(self._set_status, "⏳  Fetching metadata...", "info")
             data = fetch_deezer_album(item_id)
             if data and not data.get("error"):
                 GLib.idle_add(self._apply_deezer_meta, data)
+                GLib.idle_add(self._progress_init_tracks,
+                              metadata.deezer_album_tracks(data))
         elif service == "deezer_track" and item_id:
             GLib.idle_add(self._set_status, "⏳  Fetching metadata...", "info")
             data = fetch_deezer_track_album(item_id)
@@ -1190,6 +1221,10 @@ class AurynApp:
         self._log("\n" + status_msg + "\n", "error")
         for line in (log_lines or []):
             self._log(f"   {line}\n", "info")
+        self._progress_stop_pulse()
+        self._progress_set_summary(
+            '<span foreground="#e74c3c" size="small" weight="bold">'
+            '❌  Could not start — see Raw Log.</span>')
         self._history_set_status(self._current_history_entry, "Failed")
         self._queue_set_status(self._current_queue_item, "Failed")
         self._current_history_entry = None
@@ -2035,6 +2070,11 @@ class AurynApp:
         # collapsed traceback still counts toward the final outcome.
         self._track_streamrip_signals(line)
 
+        # Mirror the same line into the structured per-track view. Done here
+        # (before noise suppression) so it observes exactly what the outcome
+        # tally does; it never alters the line or the download itself.
+        self._feed_progress(line)
+
         # TIDAL token_expiry crash: streamrip raises ValueError on
         # float(token_expiry) when it is empty/corrupt. Scoped to a TIDAL
         # download exactly like the auth-error detection below.
@@ -2169,6 +2209,382 @@ class AurynApp:
             ]:
                 m = re.search(pat, line, re.I)
                 if m: sm("Album Quality", m.group(1)); break
+
+    # ── Vue de progression structurée ──────────────────────────────────────
+    #
+    # A clean, scannable per-track view that supplements the raw log. It is
+    # initialised from the album/playlist metadata Auryn already resolves
+    # (real song titles, in order) and otherwise discovers tracks by safely
+    # parsing streamrip output. It is OBSERVATIONAL ONLY: it reads the same
+    # lines the log pump emits and never alters the download pipeline, the
+    # queue/history, or the protected metadata sidebar. The model lives in
+    # the GTK-free core.download_session so its logic is unit-tested.
+
+    # Column widths (px) shared by the header and every track row so the list
+    # lines up like a table without a heavyweight GtkTreeView.
+    _PROG_W_NUM = 28
+    _PROG_W_STATUS = 104
+    _PROG_W_PROGRESS = 132
+
+    _PROG_STATUS_COLORS = {
+        dsession.QUEUED:      "#888888",
+        dsession.DOWNLOADING: "#14B8A6",
+        dsession.COMPLETE:    "#87a556",
+        dsession.SKIPPED:     "#e0a83b",
+        dsession.ERROR:       "#e74c3c",
+    }
+
+    @staticmethod
+    def _prog_escape(text):
+        return (str(text)
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;"))
+
+    def _build_progress_tab(self):
+        """Create the structured progress tab and make it the default page."""
+        scroll = Gtk.ScrolledWindow()
+        scroll.set_name("log_scroll")
+        scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scroll.set_hexpand(True)
+        scroll.set_vexpand(True)
+
+        container = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        container.set_margin_start(8)
+        container.set_margin_end(8)
+        container.set_margin_top(8)
+        container.set_margin_bottom(8)
+
+        self.progress_summary_lbl = Gtk.Label()
+        self.progress_summary_lbl.set_name("progress_summary")
+        self.progress_summary_lbl.set_halign(Gtk.Align.START)
+        self.progress_summary_lbl.set_ellipsize(Pango.EllipsizeMode.END)
+        container.pack_start(self.progress_summary_lbl, False, False, 0)
+
+        self.progress_header = self._progress_build_header()
+        container.pack_start(self.progress_header, False, False, 0)
+
+        self.progress_empty_label = Gtk.Label()
+        self.progress_empty_label.set_halign(Gtk.Align.CENTER)
+        self.progress_empty_label.set_valign(Gtk.Align.CENTER)
+        self.progress_empty_label.set_margin_top(24)
+        self.progress_empty_label.set_margin_bottom(24)
+        self.progress_empty_label.set_markup(
+            '<span foreground="#555555" size="small"><i>Track progress will '
+            'appear here when a download starts.</i></span>')
+        container.pack_start(self.progress_empty_label, False, False, 0)
+
+        self.progress_listbox = Gtk.ListBox()
+        self.progress_listbox.set_selection_mode(Gtk.SelectionMode.NONE)
+        self.progress_listbox.set_can_focus(False)
+        container.pack_start(self.progress_listbox, True, True, 0)
+
+        scroll.add(container)
+
+        tab_label = Gtk.Label(label="Progress")
+        self.notebook.insert_page(scroll, tab_label, 0)
+        self.notebook.show_all()
+        self.notebook.set_current_page(0)
+
+    def _progress_build_header(self):
+        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        box.get_style_context().add_class("progress-head")
+
+        def head(text, width=None, expand=False):
+            lbl = Gtk.Label()
+            lbl.set_halign(Gtk.Align.START)
+            lbl.set_markup(
+                f'<span size="x-small" letter_spacing="200">{text}</span>')
+            if width:
+                lbl.set_size_request(width, -1)
+            box.pack_start(lbl, expand, True, 0)
+
+        head("#", self._PROG_W_NUM)
+        head("TITLE", expand=True)
+        head("STATUS", self._PROG_W_STATUS)
+        head("PROGRESS", self._PROG_W_PROGRESS)
+        return box
+
+    def _progress_build_row(self, track):
+        row = Gtk.ListBoxRow()
+        row.set_can_focus(False)
+        row.get_style_context().add_class("progress-row")
+
+        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        box.set_margin_start(10)
+        box.set_margin_end(10)
+        box.set_margin_top(6)
+        box.set_margin_bottom(6)
+
+        num_lbl = Gtk.Label()
+        num_lbl.set_halign(Gtk.Align.START)
+        num_lbl.set_valign(Gtk.Align.CENTER)
+        num_lbl.set_size_request(self._PROG_W_NUM, -1)
+        box.pack_start(num_lbl, False, False, 0)
+
+        title_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=1)
+        title_box.set_hexpand(True)
+        title_box.set_valign(Gtk.Align.CENTER)
+        title_lbl = Gtk.Label()
+        title_lbl.set_halign(Gtk.Align.START)
+        title_lbl.set_ellipsize(Pango.EllipsizeMode.END)
+        title_lbl.set_max_width_chars(40)
+        title_box.pack_start(title_lbl, False, False, 0)
+        artist_lbl = Gtk.Label()
+        artist_lbl.set_halign(Gtk.Align.START)
+        artist_lbl.set_ellipsize(Pango.EllipsizeMode.END)
+        artist_lbl.set_max_width_chars(40)
+        title_box.pack_start(artist_lbl, False, False, 0)
+        box.pack_start(title_box, True, True, 0)
+
+        status_lbl = Gtk.Label()
+        status_lbl.set_halign(Gtk.Align.START)
+        status_lbl.set_valign(Gtk.Align.CENTER)
+        status_lbl.set_size_request(self._PROG_W_STATUS, -1)
+        box.pack_start(status_lbl, False, False, 0)
+
+        prog_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
+        prog_box.set_valign(Gtk.Align.CENTER)
+        prog_box.set_size_request(self._PROG_W_PROGRESS, -1)
+        bar = Gtk.ProgressBar()
+        bar.get_style_context().add_class("track-bar")
+        bar.set_valign(Gtk.Align.CENTER)
+        bar.set_hexpand(True)
+        prog_box.pack_start(bar, False, False, 0)
+        detail_lbl = Gtk.Label()
+        detail_lbl.set_halign(Gtk.Align.START)
+        detail_lbl.set_ellipsize(Pango.EllipsizeMode.END)
+        detail_lbl.set_max_width_chars(22)
+        prog_box.pack_start(detail_lbl, False, False, 0)
+        box.pack_start(prog_box, False, False, 0)
+
+        row.add(box)
+        return {
+            "row": row, "num": num_lbl, "title": title_lbl,
+            "artist": artist_lbl, "status": status_lbl,
+            "bar": bar, "detail": detail_lbl,
+        }
+
+    def _progress_reset(self):
+        """Clear the structured view back to its empty state."""
+        self._progress_stop_pulse()
+        if getattr(self, "progress_listbox", None) is not None:
+            for child in self.progress_listbox.get_children():
+                self.progress_listbox.remove(child)
+        self._progress_rows = []
+        if getattr(self, "progress_empty_label", None) is not None:
+            self.progress_empty_label.show()
+        if getattr(self, "progress_header", None) is not None:
+            self.progress_header.hide()
+        self._progress_set_summary(
+            '<span foreground="#777777" size="small">Ready — paste a URL to '
+            'begin.</span>')
+
+    def _progress_set_summary(self, markup):
+        lbl = getattr(self, "progress_summary_lbl", None)
+        if lbl is None:
+            return
+        try:
+            lbl.set_markup(markup)
+        except Exception:
+            pass
+
+    def _progress_ensure_rows(self):
+        """Append widget rows until there is one per session track."""
+        if self._dl_session is None:
+            return
+        added = False
+        while len(self._progress_rows) < len(self._dl_session.tracks):
+            track = self._dl_session.tracks[len(self._progress_rows)]
+            refs = self._progress_build_row(track)
+            self._progress_rows.append(refs)
+            self.progress_listbox.add(refs["row"])
+            added = True
+        if self._dl_session.tracks:
+            self.progress_empty_label.hide()
+            self.progress_header.show()
+        if added:
+            self.progress_listbox.show_all()
+
+    def _progress_render_row(self, i):
+        if i < 0 or i >= len(self._progress_rows):
+            return
+        if self._dl_session is None or i >= len(self._dl_session.tracks):
+            return
+        track = self._dl_session.tracks[i]
+        refs = self._progress_rows[i]
+
+        refs["num"].set_markup(
+            f'<span foreground="#555555" size="small">'
+            f'{self._prog_escape(track.number)}</span>')
+
+        title = track.title or "Unknown title"
+        refs["title"].set_markup(
+            f'<span foreground="#e8e8e8" size="small">'
+            f'{self._prog_escape(title)}</span>')
+        if track.artist:
+            refs["artist"].set_markup(
+                f'<span foreground="#666666" size="x-small">'
+                f'{self._prog_escape(track.artist)}</span>')
+            refs["artist"].show()
+        else:
+            refs["artist"].hide()
+
+        color = self._PROG_STATUS_COLORS.get(track.status, "#888888")
+        refs["status"].set_markup(
+            f'<span foreground="{color}" size="small" weight="bold">'
+            f'● {track.status}</span>')
+
+        self._progress_style_bar(refs["bar"], track)
+        refs["detail"].set_markup(self._progress_detail_markup(track))
+
+    def _progress_style_bar(self, bar, track):
+        ctx = bar.get_style_context()
+        for cls in ("bar-done", "bar-error", "bar-skip"):
+            ctx.remove_class(cls)
+        status = track.status
+        if status == dsession.COMPLETE:
+            ctx.add_class("bar-done")
+            bar.set_fraction(1.0)
+        elif status == dsession.ERROR:
+            ctx.add_class("bar-error")
+            bar.set_fraction(1.0)
+        elif status == dsession.SKIPPED:
+            ctx.add_class("bar-skip")
+            bar.set_fraction(1.0)
+        elif status == dsession.DOWNLOADING:
+            bar.pulse()  # the pulse timer keeps it animating
+        else:  # QUEUED
+            bar.set_fraction(0.0)
+
+    def _progress_detail_markup(self, track):
+        if track.status == dsession.DOWNLOADING:
+            txt = track.speed or "downloading…"
+            color = "#14B8A6"
+        elif track.status == dsession.COMPLETE:
+            txt = self._progress_format_elapsed(track.elapsed) or "done"
+            color = "#6f8f48"
+        elif track.status == dsession.SKIPPED:
+            txt = "skipped"
+            color = "#9a7b2e"
+        elif track.status == dsession.ERROR:
+            txt = track.detail or "error"
+            color = "#b3493d"
+        else:
+            txt = "queued"
+            color = "#555555"
+        return (f'<span foreground="{color}" size="x-small">'
+                f'{self._prog_escape(txt)}</span>')
+
+    @staticmethod
+    def _progress_format_elapsed(seconds):
+        if seconds is None:
+            return ""
+        seconds = int(round(seconds))
+        if seconds < 60:
+            return f"{seconds}s"
+        minutes, secs = divmod(seconds, 60)
+        return f"{minutes}m{secs:02d}s"
+
+    def _feed_progress(self, line):
+        """Forward one log line to the structured model and refresh rows."""
+        if self._dl_session is None:
+            return
+        changed = self._dl_session.feed_line(line)
+        self._progress_ensure_rows()
+        for i in changed:
+            self._progress_render_row(i)
+        self._progress_refresh_summary()
+        if self._dl_session.counts()["downloading"] > 0:
+            self._progress_start_pulse()
+
+    def _progress_init_tracks(self, tracks):
+        """Seed the structured view from resolved album/playlist metadata."""
+        if self._dl_session is None or not tracks:
+            return False
+        self._dl_session.init_from_metadata(tracks)
+        for child in self.progress_listbox.get_children():
+            self.progress_listbox.remove(child)
+        self._progress_rows = []
+        self._progress_ensure_rows()
+        for i in range(len(self._dl_session.tracks)):
+            self._progress_render_row(i)
+        self._progress_refresh_summary()
+        return False
+
+    def _progress_refresh_summary(self, final_outcome=None):
+        if self._dl_session is None:
+            return
+        c = self._dl_session.counts()
+        total = c["total"]
+        done = c["complete"]
+        if final_outcome == streamrip_status.SUCCESS:
+            plural = "s" if total != 1 else ""
+            markup = (f'<span foreground="#87a556" size="small" weight="bold">'
+                      f'✅  All {total} track{plural} downloaded.</span>')
+        elif final_outcome == streamrip_status.PARTIAL:
+            parts = [f"{done}/{total} complete"]
+            if c["skipped"]:
+                parts.append(f'{c["skipped"]} skipped')
+            errs = c["errors"] or c["error_signals"]
+            if errs:
+                parts.append(f'{errs} error{"s" if errs != 1 else ""}')
+            markup = (f'<span foreground="#e0a83b" size="small" weight="bold">'
+                      f'⚠  {self._prog_escape(" · ".join(parts))}'
+                      f' — details in Raw Log.</span>')
+        elif final_outcome == streamrip_status.INVALID_URL:
+            markup = ('<span foreground="#e74c3c" size="small" weight="bold">'
+                      '❌  URL rejected by streamrip — see Raw Log.'
+                      '</span>')
+        elif final_outcome == streamrip_status.FAILED:
+            markup = ('<span foreground="#e74c3c" size="small" weight="bold">'
+                      '❌  Download failed — see Raw Log.</span>')
+        elif total > 0:
+            markup = (f'<span foreground="#14B8A6" size="small">'
+                      f'Downloading… {done}/{total} complete.</span>')
+        else:
+            markup = ('<span foreground="#777777" size="small">'
+                      'Preparing download…</span>')
+        self._progress_set_summary(markup)
+
+    def _progress_finalize(self, outcome):
+        if self._dl_session is None:
+            return
+        self._dl_session.finalize(outcome)
+        self._progress_ensure_rows()
+        for i in range(len(self._progress_rows)):
+            self._progress_render_row(i)
+        self._progress_refresh_summary(final_outcome=outcome)
+        self._progress_stop_pulse()
+
+    def _progress_start_pulse(self):
+        if self._progress_pulse_timer is not None:
+            return
+        self._progress_pulse_timer = GLib.timeout_add(
+            140, self._progress_pulse_tick)
+
+    def _progress_pulse_tick(self):
+        if self._dl_session is None:
+            self._progress_pulse_timer = None
+            return False
+        any_active = False
+        for i, track in enumerate(self._dl_session.tracks):
+            if (track.status == dsession.DOWNLOADING
+                    and i < len(self._progress_rows)):
+                self._progress_rows[i]["bar"].pulse()
+                any_active = True
+        if not any_active:
+            self._progress_pulse_timer = None
+            return False
+        return True
+
+    def _progress_stop_pulse(self):
+        if self._progress_pulse_timer is not None:
+            try:
+                GLib.source_remove(self._progress_pulse_timer)
+            except Exception:
+                pass
+            self._progress_pulse_timer = None
 
     # ── Fin ───────────────────────────────────────────────────────────────────
 
@@ -2551,16 +2967,29 @@ class AurynApp:
                         and self._process.returncode == -15)
         if user_stopped:
             self._finish_failed()
+            final_outcome = streamrip_status.FAILED
         else:
-            outcome = self._compute_download_outcome(success)
-            if outcome == streamrip_status.SUCCESS:
+            final_outcome = self._compute_download_outcome(success)
+            # Honour the structured model: never claim a clean finish if it
+            # observed errors/skips (defensive — both read the same signals).
+            if (final_outcome == streamrip_status.SUCCESS
+                    and self._dl_session is not None
+                    and self._dl_session.has_problems()):
+                final_outcome = streamrip_status.PARTIAL
+            if final_outcome == streamrip_status.SUCCESS:
                 self._finish_full_success()
-            elif outcome == streamrip_status.PARTIAL:
+            elif final_outcome == streamrip_status.PARTIAL:
                 self._finish_with_warnings()
-            elif outcome == streamrip_status.INVALID_URL:
+            elif final_outcome == streamrip_status.INVALID_URL:
                 self._finish_invalid_url()
             else:
                 self._finish_failed()
+
+        self._progress_finalize(final_outcome)
+        if user_stopped:
+            self._progress_set_summary(
+                '<span foreground="#e0a83b" size="small" weight="bold">'
+                '⏹  Download stopped.</span>')
 
         self._post_download_config_audit()
         tidal_corrupted = (
@@ -2849,6 +3278,10 @@ class AurynApp:
         self._log(
             "\n🔐  TIDAL download skipped: saved auth is corrupt/incomplete.\n",
             "error")
+        self._progress_stop_pulse()
+        self._progress_set_summary(
+            '<span foreground="#e74c3c" size="small" weight="bold">'
+            '🔐  TIDAL auth needs repair — see Raw Log.</span>')
         self._history_set_status(self._current_history_entry, "Failed")
         self._queue_set_status(self._current_queue_item, "Failed")
         self._current_history_entry = None

--- a/src/Auryn.ui
+++ b/src/Auryn.ui
@@ -525,7 +525,7 @@
                       <object class="GtkLabel" id="label_tab_log">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">Log</property>
+                        <property name="label" translatable="yes">Raw Log</property>
                       </object>
                       <packing>
                         <property name="tab-fill">False</property>

--- a/src/core/download_session.py
+++ b/src/core/download_session.py
@@ -1,0 +1,351 @@
+"""GTK-free structured model for a single download's per-track progress.
+
+Auryn historically showed only streamrip's raw terminal output while a
+download ran. This module backs the new structured progress view: an
+honest, scannable list of tracks with a status, a result and (when
+available) a transfer speed / elapsed time — without ever touching the
+streamrip download pipeline itself.
+
+It is intentionally observational:
+
+  * It is *initialised* from the album / playlist metadata Auryn already
+    resolves for the sidebar (real song titles, in order), and otherwise
+    falls back to parsing streamrip stdout via :mod:`core.progress_parse`.
+  * It is *fed* the same cleaned output lines the GTK log pump already
+    emits, so it adds zero new subprocess handling.
+  * It reuses :mod:`core.streamrip_status` for done / skip / error /
+    finished classification so the structured outcome can never disagree
+    with the headline outcome the rest of the UI computes.
+
+Kept dependency-free (apart from sibling ``core`` modules) and free of
+GTK so it can be unit-tested without the application module.
+"""
+
+import time
+
+from core import progress_parse
+from core import streamrip_status
+
+
+# Per-track statuses surfaced in the structured view.
+QUEUED = "Queued"
+DOWNLOADING = "Downloading"
+COMPLETE = "Complete"
+SKIPPED = "Skipped"
+ERROR = "Error"
+
+_TERMINAL = (COMPLETE, SKIPPED, ERROR)
+
+
+class TrackProgress:
+    """One row in the structured download view.
+
+    All fields are plain data; the GTK layer reads them to render / update
+    a row and never the other way around.
+    """
+
+    def __init__(self, number, title, artist=""):
+        self.number = number
+        self.title = (title or "").strip()
+        self.artist = (artist or "").strip()
+        self.status = QUEUED
+        self.speed = ""
+        self.detail = ""          # short result / error text
+        self.started = None       # clock() value when it went Downloading
+        self.finished = None      # clock() value when it reached a terminal
+        self.elapsed = None       # seconds (float) once finished
+        self._seq = 0             # start-order tie-breaker for concurrency
+
+    @property
+    def is_terminal(self):
+        return self.status in _TERMINAL
+
+
+class DownloadSession:
+    """Accumulates per-track progress for one download.
+
+    Two modes, chosen automatically:
+
+    * **Metadata-backed** — :meth:`init_from_metadata` seeds the real track
+      list up front; streamrip lines then only *advance* statuses.
+    * **Parse-only** — no metadata was available, so tracks are discovered
+      from ``Downloading <title>`` lines as the download proceeds.
+    """
+
+    def __init__(self, clock=time.monotonic):
+        self._clock = clock
+        self.tracks = []
+        self.metadata_backed = False
+        self.total_hint = 0           # parsed "N tracks" total (fallback)
+        self.completed_count = 0      # streamrip "Track Download Done" count
+        self.error_count = 0
+        self.skip_count = 0
+        self.invalid_url = False
+        self.finished_marker = False
+        self.last_speed = ""
+        self._start_seq = 0           # ordering for "oldest downloading"
+        self._last_seen_number = None  # from a standalone "Track N" line
+        self._finalized = False
+
+    # ── Initialisation ────────────────────────────────────────────────
+
+    def init_from_metadata(self, track_dicts):
+        """Seed the track list from resolved album/playlist metadata.
+
+        *track_dicts* is the list produced by ``core.metadata`` helpers:
+        ``[{"number": int, "title": str, "artist": str}, ...]``. Tolerant
+        of an empty / ``None`` list (leaves the session in parse-only mode).
+        """
+        if not track_dicts:
+            return
+        self.tracks = []
+        for i, td in enumerate(track_dicts):
+            td = td if isinstance(td, dict) else {}
+            number = td.get("number") or (i + 1)
+            self.tracks.append(
+                TrackProgress(number, td.get("title", ""),
+                              td.get("artist", "")))
+        self.metadata_backed = bool(self.tracks)
+        if self.metadata_backed:
+            self.total_hint = len(self.tracks)
+
+    # ── Derived values for the UI ─────────────────────────────────────
+
+    def effective_total(self):
+        """Best estimate of the total track count."""
+        return max(self.total_hint, len(self.tracks))
+
+    def overall_fraction(self):
+        """Completed fraction in ``0.0..1.0`` for an overall progress bar."""
+        total = self.effective_total()
+        if total <= 0:
+            return 0.0
+        return min(self.completed_count / total, 1.0)
+
+    def counts(self):
+        """Return a snapshot of the tallies the summary banner needs."""
+        done = sum(1 for t in self.tracks if t.status == COMPLETE)
+        return {
+            "total": self.effective_total(),
+            "complete": done,
+            "skipped": sum(1 for t in self.tracks if t.status == SKIPPED),
+            "errors": sum(1 for t in self.tracks if t.status == ERROR),
+            "downloading": sum(1 for t in self.tracks
+                               if t.status == DOWNLOADING),
+            # Raw streamrip-signal tallies (independent of per-track mapping)
+            # so the banner stays honest even in parse-only mode.
+            "done_signals": self.completed_count,
+            "error_signals": self.error_count,
+            "skip_signals": self.skip_count,
+        }
+
+    def has_problems(self):
+        """True if any error / skip / invalid-URL signal was observed."""
+        return bool(self.error_count or self.skip_count or self.invalid_url)
+
+    def outcome(self, process_ok):
+        """Classify the run exactly like the rest of the UI does."""
+        return streamrip_status.classify_outcome(
+            finished=self.finished_marker,
+            error_count=self.error_count,
+            skip_count=self.skip_count,
+            invalid_url=self.invalid_url,
+            process_ok=process_ok,
+        )
+
+    # ── Internal track-state transitions ──────────────────────────────
+
+    def _active_index(self):
+        """Most recently started still-Downloading track, or ``None``."""
+        best = None
+        best_seq = -1
+        for i, t in enumerate(self.tracks):
+            if t.status == DOWNLOADING and t._seq > best_seq:
+                best, best_seq = i, t._seq
+        return best
+
+    def _oldest_downloading(self):
+        best = None
+        best_seq = None
+        for i, t in enumerate(self.tracks):
+            if t.status == DOWNLOADING and (best_seq is None
+                                            or t._seq < best_seq):
+                best, best_seq = i, t._seq
+        return best
+
+    def _first_non_terminal(self):
+        for i, t in enumerate(self.tracks):
+            if not t.is_terminal:
+                return i
+        return None
+
+    def _begin(self, i):
+        t = self.tracks[i]
+        t.status = DOWNLOADING
+        t.started = self._clock()
+        self._start_seq += 1
+        t._seq = self._start_seq
+
+    def _terminate(self, i, status, detail=""):
+        t = self.tracks[i]
+        t.status = status
+        if detail:
+            t.detail = detail
+        t.finished = self._clock()
+        if t.started is not None and t.finished is not None:
+            t.elapsed = max(0.0, t.finished - t.started)
+
+    # ── Line feed ─────────────────────────────────────────────────────
+
+    def feed_line(self, line):
+        """Update the model from one cleaned streamrip output line.
+
+        Returns the set of track indices whose row needs re-rendering (a
+        newly discovered track's index is included so the UI can append a
+        row). Never raises.
+        """
+        changed = set()
+        if not line:
+            return changed
+        try:
+            return self._feed_line(line, changed)
+        except Exception:
+            # The structured view is a best-effort overlay; a parsing edge
+            # case must never break the log pump that drives the download.
+            return changed
+
+    def _feed_line(self, line, changed):
+        if streamrip_status.line_says_finished(line):
+            self.finished_marker = True
+        if streamrip_status.line_is_invalid_url(line):
+            self.invalid_url = True
+            return changed
+        self._absorb_metrics(line, changed)
+        return self._absorb_event(line, changed)
+
+    def _absorb_metrics(self, line, changed):
+        """Soak up non-terminal signals: track total, number and speed."""
+        if not self.metadata_backed:
+            total = progress_parse.extract_track_total(line)
+            if total and total > self.total_hint:
+                self.total_hint = total
+            number = progress_parse.extract_track_number(line)
+            if number is not None:
+                self._last_seen_number = number
+        speed = progress_parse.extract_speed(line)
+        if speed:
+            self.last_speed = speed
+            i = self._active_index()
+            if i is not None:
+                self.tracks[i].speed = speed
+                changed.add(i)
+
+    def _absorb_event(self, line, changed):
+        """Apply at most one state transition (skip / done / error / start).
+
+        Order mirrors core.streamrip_status: skip before error so a
+        "Skipping ..." line is never miscounted as an error.
+        """
+        if streamrip_status.line_is_skip(line):
+            self.skip_count += 1
+            self._resolve_one(SKIPPED, "Skipped", changed, prefer_active=True)
+            return changed
+        if progress_parse.line_is_track_done(line):
+            self.completed_count += 1
+            self._resolve_one(COMPLETE, "Done", changed, prefer_active=False)
+            return changed
+        if streamrip_status.line_is_error(line):
+            self.error_count += 1
+            i = self._active_index()
+            if i is not None:
+                self._terminate(i, ERROR, "Error")
+                changed.add(i)
+            return changed
+        title = progress_parse.extract_track_title(line)
+        if title:
+            i = self._note_downloading(title)
+            if i is not None:
+                changed.add(i)
+        return changed
+
+    def _resolve_one(self, status, detail, changed, *, prefer_active):
+        """Move one in-flight (or next pending) track to a terminal *status*.
+
+        ``prefer_active`` picks the most recently started track (skips, which
+        usually concern the line just announced); otherwise the oldest
+        downloading one is completed first (FIFO under concurrency).
+        """
+        i = self._active_index() if prefer_active else self._oldest_downloading()
+        if i is None:
+            i = self._first_non_terminal()
+        if i is not None:
+            if status == COMPLETE:
+                self.tracks[i].speed = ""
+            self._terminate(i, status, detail)
+            changed.add(i)
+
+    def _note_downloading(self, title):
+        """Mark the track matching *title* as Downloading; return its index."""
+        norm = progress_parse.normalize_title(title)
+
+        if self.metadata_backed:
+            # Prefer an exact, still-queued title match; otherwise advance
+            # the next queued row without renaming (titles already trusted).
+            for i, t in enumerate(self.tracks):
+                if (t.status == QUEUED
+                        and progress_parse.normalize_title(t.title) == norm):
+                    self._begin(i)
+                    return i
+            i = self._first_queued()
+            if i is not None:
+                self._begin(i)
+                return i
+            return None
+
+        # Parse-only mode: reuse an existing non-terminal row for this
+        # title, else discover a new track.
+        for i, t in enumerate(self.tracks):
+            if (not t.is_terminal
+                    and progress_parse.normalize_title(t.title) == norm):
+                if t.status != DOWNLOADING:
+                    self._begin(i)
+                return i
+        number = (self._last_seen_number
+                  if self._last_seen_number is not None
+                  else len(self.tracks) + 1)
+        self._last_seen_number = None
+        track = TrackProgress(number, title)
+        self.tracks.append(track)
+        i = len(self.tracks) - 1
+        self._begin(i)
+        return i
+
+    def _first_queued(self):
+        for i, t in enumerate(self.tracks):
+            if t.status == QUEUED:
+                return i
+        return None
+
+    # ── Finalisation ──────────────────────────────────────────────────
+
+    def finalize(self, outcome):
+        """Reconcile non-terminal rows once the download has ended.
+
+        Returns the set of changed indices. Conservative on purpose: a
+        clean run completes every row, while any other outcome only resolves
+        rows that were left mid-flight (Downloading) — queued rows that were
+        never confirmed stay Queued rather than being claimed done.
+        """
+        self._finalized = True
+        changed = set()
+        if outcome == streamrip_status.SUCCESS:
+            for i, t in enumerate(self.tracks):
+                if not t.is_terminal:
+                    self._terminate(i, COMPLETE, "Done")
+                    changed.add(i)
+        else:
+            for i, t in enumerate(self.tracks):
+                if t.status == DOWNLOADING:
+                    self._terminate(i, ERROR, "Interrupted")
+                    changed.add(i)
+        return changed

--- a/src/core/metadata.py
+++ b/src/core/metadata.py
@@ -129,3 +129,70 @@ def qobuz_album_fields(data):
         "cover_url": cover_url,
         "cover_fallback": cover_fallback,
     }
+
+
+# ── Track lists for the structured progress view ──────────────────────────
+#
+# These feed core.download_session so the progress view can show real song
+# titles in order before streamrip prints anything. Like the field helpers
+# above they must tolerate partial / None / oddly-shaped payloads and always
+# return a (possibly empty) list — never raise.
+
+def _track_entry(number, title, artist):
+    """Build one normalised track dict, or ``None`` if it has no title."""
+    title = (str(title).strip() if title else "")
+    if not title:
+        return None
+    return {
+        "number": number,
+        "title": title,
+        "artist": (str(artist).strip() if artist else ""),
+    }
+
+
+def deezer_album_tracks(data):
+    """Return ``[{number, title, artist}, ...]`` from a Deezer album payload.
+
+    Deezer nests the track list under ``tracks -> data``. Missing / partial
+    entries are skipped rather than raising, and the track position falls
+    back to the list order when absent.
+    """
+    data = _safe_dict(data)
+    items = _safe_dict(data.get("tracks")).get("data")
+    if not isinstance(items, list):
+        return []
+    out = []
+    for i, raw in enumerate(items):
+        raw = _safe_dict(raw)
+        number = raw.get("track_position") or (i + 1)
+        artist = _safe_dict(raw.get("artist")).get("name", "") or ""
+        entry = _track_entry(number, raw.get("title"), artist)
+        if entry:
+            out.append(entry)
+    return out
+
+
+def qobuz_album_tracks(data):
+    """Return ``[{number, title, artist}, ...]`` from a Qobuz album payload.
+
+    Qobuz nests the track list under ``tracks -> items`` with a
+    ``performer`` per track (falling back to the album artist). Tolerant of
+    partial / None entries.
+    """
+    data = _safe_dict(data)
+    album_artist = (_safe_dict(data.get("artist")).get("name", "")
+                    or _safe_dict(data.get("performer")).get("name", "")
+                    or "")
+    items = _safe_dict(data.get("tracks")).get("items")
+    if not isinstance(items, list):
+        return []
+    out = []
+    for i, raw in enumerate(items):
+        raw = _safe_dict(raw)
+        number = raw.get("track_number") or (i + 1)
+        artist = (_safe_dict(raw.get("performer")).get("name", "")
+                  or album_artist)
+        entry = _track_entry(number, raw.get("title"), artist)
+        if entry:
+            out.append(entry)
+    return out

--- a/src/core/progress_parse.py
+++ b/src/core/progress_parse.py
@@ -1,0 +1,180 @@
+"""Pure, GTK-free extractors for streamrip progress lines.
+
+The structured download view (``core.download_session``) is initialised
+from resolved album/playlist metadata whenever possible, but it still has
+to fall back to streamrip's raw stdout when no metadata is available
+(playlists, single tracks, TIDAL / SoundCloud) or to track *which* item
+streamrip is working on right now. The helpers here turn one cleaned
+output line into a small structured signal without ever raising.
+
+Design rules (mirrors ``core.streamrip_status`` / ``core.log_format``):
+  * dependency-free and side-effect-free so it is unit-testable without
+    importing the GTK application module,
+  * every helper tolerates ``None`` / empty / unexpectedly-shaped input
+    and returns ``None`` (or a falsy default) instead of raising,
+  * extraction only — *classification* of done/skip/error/finished lines
+    stays in ``core.streamrip_status`` so there is one source of truth.
+
+These run on already-sanitised lines (ANSI / CR stripped by the output
+pump), but they re-strip a leading log-level token defensively.
+"""
+
+import re
+
+# Leading log-level / timestamp token streamrip prints, e.g.
+# "INFO  Downloading ...", "DEBUG ...", "[12:00:00] ...". Stripped so the
+# payload regexes below can anchor on the real message.
+_LOG_PREFIX_RE = re.compile(
+    r'^\s*(?:\[[^\]]*\]\s*)?(?:INFO|DEBUG|WARNING|WARN|ERROR|CRITICAL)?\s*',
+    re.I,
+)
+
+# "Track Download Done" is streamrip's per-track completion marker. The
+# existing output pump already keys the overall progress bar off it, so
+# the structured model uses the same signal to stay consistent.
+_TRACK_DONE_RE = re.compile(r'track\s+download\s+done', re.I)
+
+# A standalone "Track 1" line (the track number, printed separately from
+# the title). Must not match "Track Download Done" — the trailing anchor
+# after the digits guards that.
+_TRACK_NUM_RE = re.compile(r'^track\s+(\d+)\s*$', re.I)
+
+# Transfer speed, e.g. "1.23 MB/s". Identical shape to the speed regex the
+# output pump already uses for the footer indicator.
+_SPEED_RE = re.compile(r'([\d.]+\s*[KMG]B/s)', re.I)
+
+# Total-track count, kept deliberately strict so "Downloading track 1"
+# (a space, not a colon) can never be misread as "1 track total".
+_TOTAL_RE = (
+    re.compile(r'\btracks?\s*[:=]\s*(\d+)', re.I),
+    re.compile(r'\bfound\s+(\d+)\s+tracks?\b', re.I),
+)
+
+# Title extractors, most specific first.
+_DL_TRACK_RE = re.compile(r'downloading\s+track\b[:\s]*(.+)', re.I)
+_DL_GENERIC_RE = re.compile(r'downloading\s+(.+)', re.I)
+
+# A title that is really just a position ("1", "1 of 12") is a number, not
+# a song name — let the dedicated number line own it instead.
+_NUMERIC_TITLE_RE = re.compile(r'^\d+(?:\s+of\s+\d+)?$', re.I)
+
+# Trailing decorations streamrip appends to a "Downloading <title>" line:
+# a run of box-drawing rule characters, or a "track.py:NNN" source ref.
+_TRAILING_RULE_RE = re.compile(r'[\s\-—–─━]+$')
+_TRACKPY_NOISE_RE = re.compile(r'\s+track\.py\b.*$', re.I)
+
+# A run of 3+ rule characters marks a section banner (streamrip prints
+# "Downloading <Album> ────────" for the album header) rather than a song.
+_BANNER_RUN_RE = re.compile(r'[\-—–─━]{3,}')
+
+
+def _strip_prefix(line):
+    return _LOG_PREFIX_RE.sub('', line.rstrip('\n'), count=1)
+
+
+def line_is_track_done(line):
+    """True if *line* is streamrip's per-track completion marker."""
+    if not line:
+        return False
+    return bool(_TRACK_DONE_RE.search(line))
+
+
+def extract_speed(line):
+    """Return a transfer-speed string (``"1.2 MB/s"``) or ``None``."""
+    if not line:
+        return None
+    m = _SPEED_RE.search(line)
+    return m.group(1).strip() if m else None
+
+
+def extract_track_number(line):
+    """Return the integer from a standalone ``"Track N"`` line, or ``None``."""
+    if not line:
+        return None
+    m = _TRACK_NUM_RE.match(_strip_prefix(line).strip())
+    if not m:
+        return None
+    try:
+        return int(m.group(1))
+    except (TypeError, ValueError):
+        return None
+
+
+def extract_track_total(line):
+    """Return a total-track count from a ``"Tracks: N"`` / ``"Found N tracks"``
+    line, or ``None``. Strict on purpose so progress lines never match."""
+    if not line:
+        return None
+    for rx in _TOTAL_RE:
+        m = rx.search(line)
+        if m:
+            try:
+                n = int(m.group(1))
+            except (TypeError, ValueError):
+                return None
+            return n if n > 0 else None
+    return None
+
+
+def _clean_title(raw):
+    """Normalise the captured title fragment; return ``""`` if it is junk."""
+    title = _TRACKPY_NOISE_RE.sub('', raw)
+    title = _TRAILING_RULE_RE.sub('', title).strip()
+    # Strip one layer of matching surrounding quotes.
+    if len(title) >= 2 and title[0] in "\"'" and title[-1] == title[0]:
+        title = title[1:-1].strip()
+    if not title or len(title) > 200:
+        return ""
+    if "://" in title:
+        return ""
+    if _NUMERIC_TITLE_RE.match(title):
+        return ""
+    return title
+
+
+def extract_track_title(line):
+    """Return the song title from a ``"Downloading <title>"`` line, or ``None``.
+
+    Handles ``Downloading track 'Title'``, ``Downloading track Title`` and
+    the bare ``Downloading Title`` form. Album / playlist banner lines and
+    pure track-number lines are rejected so only real song titles come
+    back.
+    """
+    if not line:
+        return None
+    s = _strip_prefix(line).strip()
+    if not s:
+        return None
+    lo = s.lower()
+    if lo.startswith(("downloading album", "downloading playlist")):
+        return None
+    # "Downloading <Album> ────────" is the album header banner, not a song.
+    if _BANNER_RUN_RE.search(s):
+        return None
+
+    m = _DL_TRACK_RE.search(s)
+    if m:
+        title = _clean_title(m.group(1))
+        return title or None
+
+    m = _DL_GENERIC_RE.search(s)
+    if m:
+        title = _clean_title(m.group(1))
+        return title or None
+    return None
+
+
+def normalize_title(value):
+    """Return a comparison-friendly form of a title for matching.
+
+    Lowercases, trims, collapses internal whitespace and drops surrounding
+    quotes / trailing punctuation so a streamrip title and a metadata title
+    that differ only cosmetically still match.
+    """
+    if not value:
+        return ""
+    txt = str(value).strip().lower()
+    if len(txt) >= 2 and txt[0] in "\"'" and txt[-1] == txt[0]:
+        txt = txt[1:-1].strip()
+    txt = re.sub(r'\s+', ' ', txt)
+    return txt.strip(" .'\"")

--- a/tests/test_download_session.py
+++ b/tests/test_download_session.py
@@ -1,0 +1,173 @@
+"""Tests for the GTK-free structured download session model.
+
+These guard the behaviour the progress UI depends on: metadata seeds the
+track list with real titles, streamrip lines advance per-track status,
+the structured outcome agrees with core.streamrip_status, and a clean run
+ends with every track Complete (so the UI never claims "complete" while
+errors are present).
+"""
+
+from core import download_session as ds
+from core import streamrip_status
+
+
+class FakeClock:
+    """Deterministic monotonic stand-in so elapsed times are testable."""
+
+    def __init__(self):
+        self.t = 0.0
+
+    def tick(self, dt=1.0):
+        self.t += dt
+
+    def __call__(self):
+        return self.t
+
+
+def _meta(*titles):
+    return [{"number": i + 1, "title": t, "artist": "Daft Punk"}
+            for i, t in enumerate(titles)]
+
+
+# ── Metadata-backed mode ──────────────────────────────────────────────────
+
+def test_init_from_metadata_seeds_queued_tracks():
+    s = ds.DownloadSession()
+    s.init_from_metadata(_meta("One More Time", "Aerodynamic", "Digital Love"))
+    assert s.metadata_backed is True
+    assert [t.title for t in s.tracks] == [
+        "One More Time", "Aerodynamic", "Digital Love"]
+    assert all(t.status == ds.QUEUED for t in s.tracks)
+    assert s.effective_total() == 3
+
+
+def test_downloading_then_done_marks_tracks_complete_in_order():
+    s = ds.DownloadSession()
+    s.init_from_metadata(_meta("One More Time", "Aerodynamic"))
+
+    s.feed_line("Downloading track 'One More Time'")
+    assert s.tracks[0].status == ds.DOWNLOADING
+
+    s.feed_line("Track Download Done")
+    assert s.tracks[0].status == ds.COMPLETE
+    assert s.tracks[1].status == ds.QUEUED
+
+    s.feed_line("Downloading track 'Aerodynamic'")
+    s.feed_line("Track Download Done")
+    assert s.tracks[1].status == ds.COMPLETE
+    assert s.completed_count == 2
+
+
+def test_title_mismatch_still_advances_next_queued_row():
+    # Metadata titles are trusted; a slightly different streamrip title must
+    # not orphan progress — the next queued row advances instead.
+    s = ds.DownloadSession()
+    s.init_from_metadata(_meta("Track A", "Track B"))
+    s.feed_line("Downloading track 'Something Else Entirely'")
+    assert s.tracks[0].status == ds.DOWNLOADING
+    assert s.tracks[0].title == "Track A"  # not renamed
+
+
+def test_skip_and_error_are_counted_and_reflected():
+    s = ds.DownloadSession()
+    s.init_from_metadata(_meta("A", "B", "C"))
+
+    s.feed_line("Skipping 'A' (already exists)")
+    assert s.skip_count == 1
+    assert s.tracks[0].status == ds.SKIPPED
+
+    s.feed_line("Downloading track 'B'")
+    s.feed_line("ERROR  Error downloading track: list index out of range")
+    assert s.error_count == 1
+    assert s.tracks[1].status == ds.ERROR
+
+
+def test_speed_attaches_to_active_track():
+    s = ds.DownloadSession()
+    s.init_from_metadata(_meta("A"))
+    s.feed_line("Downloading track 'A'")
+    s.feed_line("progress 2.50 MB/s")
+    assert s.tracks[0].speed == "2.50 MB/s"
+    assert s.last_speed == "2.50 MB/s"
+
+
+def test_elapsed_recorded_with_injected_clock():
+    clock = FakeClock()
+    s = ds.DownloadSession(clock=clock)
+    s.init_from_metadata(_meta("A"))
+    s.feed_line("Downloading track 'A'")
+    clock.tick(4.0)
+    s.feed_line("Track Download Done")
+    assert s.tracks[0].elapsed == 4.0
+
+
+# ── Parse-only fallback mode ──────────────────────────────────────────────
+
+def test_parse_only_discovers_tracks_from_output():
+    s = ds.DownloadSession()
+    # No metadata -> parse-only. "Track N" then "Downloading <title>".
+    s.feed_line("Track 1")
+    s.feed_line("Downloading Good Life")
+    assert s.metadata_backed is False
+    assert len(s.tracks) == 1
+    assert s.tracks[0].number == 1
+    assert s.tracks[0].title == "Good Life"
+    assert s.tracks[0].status == ds.DOWNLOADING
+
+    s.feed_line("Track Download Done")
+    assert s.tracks[0].status == ds.COMPLETE
+
+
+def test_parse_only_total_hint_from_output():
+    s = ds.DownloadSession()
+    s.feed_line("Found 12 tracks")
+    assert s.effective_total() == 12
+
+
+# ── Outcome + finalisation ────────────────────────────────────────────────
+
+def test_outcome_matches_streamrip_status_for_clean_run():
+    s = ds.DownloadSession()
+    s.init_from_metadata(_meta("A", "B"))
+    s.feed_line("Downloading track 'A'")
+    s.feed_line("Track Download Done")
+    s.feed_line("Downloading track 'B'")
+    s.feed_line("Track Download Done")
+    s.feed_line("All downloads finished!")
+    assert s.outcome(process_ok=True) == streamrip_status.SUCCESS
+    assert s.has_problems() is False
+
+
+def test_finalize_success_completes_all_rows():
+    s = ds.DownloadSession()
+    s.init_from_metadata(_meta("A", "B", "C"))
+    s.feed_line("Downloading track 'A'")
+    s.feed_line("Track Download Done")
+    # B and C never got individual lines; a clean outcome completes them.
+    s.finalize(streamrip_status.SUCCESS)
+    assert all(t.status == ds.COMPLETE for t in s.tracks)
+
+
+def test_finalize_partial_only_resolves_inflight_rows():
+    s = ds.DownloadSession()
+    s.init_from_metadata(_meta("A", "B", "C"))
+    s.feed_line("Downloading track 'A'")
+    s.feed_line("Track Download Done")        # A complete
+    s.feed_line("Downloading track 'B'")      # B left mid-flight
+    s.finalize(streamrip_status.PARTIAL)
+    assert s.tracks[0].status == ds.COMPLETE
+    assert s.tracks[1].status == ds.ERROR     # interrupted
+    assert s.tracks[2].status == ds.QUEUED    # never started -> honest
+
+
+def test_invalid_url_signal_recorded():
+    s = ds.DownloadSession()
+    s.feed_line("Found invalid url: https://deezer.com/page")
+    assert s.invalid_url is True
+    assert s.outcome(process_ok=False) == streamrip_status.INVALID_URL
+
+
+def test_feed_line_never_raises_on_garbage():
+    s = ds.DownloadSession()
+    for bad in (None, "", "\x00\x01", "Downloading " + "x" * 5000):
+        s.feed_line(bad)  # must not raise

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -161,3 +161,53 @@ def test_qobuz_handles_none_and_non_dict_input():
         assert f["quality"] == ""
         assert f["cover_url"] == ""
         assert f["cover_fallback"] == ""
+
+
+# ── Track lists for the structured progress view ──────────────────────────
+
+def test_deezer_album_tracks_normalises_titles_and_order():
+    data = {
+        "tracks": {"data": [
+            {"title": "One More Time", "track_position": 1,
+             "artist": {"name": "Daft Punk"}},
+            {"title": "Aerodynamic", "track_position": 2,
+             "artist": {"name": "Daft Punk"}},
+        ]}
+    }
+    tracks = metadata.deezer_album_tracks(data)
+    assert [t["title"] for t in tracks] == ["One More Time", "Aerodynamic"]
+    assert [t["number"] for t in tracks] == [1, 2]
+    assert tracks[0]["artist"] == "Daft Punk"
+
+
+def test_deezer_album_tracks_falls_back_to_index_and_skips_empty():
+    data = {"tracks": {"data": [
+        {"title": "Has Title"},
+        {"title": "", "artist": None},   # skipped (no title)
+        {"artist": {"name": "X"}},        # skipped (no title)
+    ]}}
+    tracks = metadata.deezer_album_tracks(data)
+    assert len(tracks) == 1
+    assert tracks[0]["number"] == 1
+    assert tracks[0]["artist"] == ""
+
+
+def test_qobuz_album_tracks_uses_performer_then_album_artist():
+    data = {
+        "artist": {"name": "Air"},
+        "tracks": {"items": [
+            {"title": "La Femme d'Argent", "track_number": 1,
+             "performer": {"name": "Air feat. X"}},
+            {"title": "Sexy Boy", "track_number": 2},  # no performer
+        ]},
+    }
+    tracks = metadata.qobuz_album_tracks(data)
+    assert tracks[0]["artist"] == "Air feat. X"
+    assert tracks[1]["artist"] == "Air"        # album-artist fallback
+    assert [t["number"] for t in tracks] == [1, 2]
+
+
+def test_track_lists_tolerate_none_and_bad_shapes():
+    for bad in (None, [], "oops", 42, {"tracks": None}, {"tracks": "x"}):
+        assert metadata.deezer_album_tracks(bad) == []
+        assert metadata.qobuz_album_tracks(bad) == []

--- a/tests/test_progress_parse.py
+++ b/tests/test_progress_parse.py
@@ -1,0 +1,87 @@
+"""Tests for the GTK-free streamrip progress-line extractors.
+
+These back the structured download view's parse-only fallback, so they
+guard that real song titles are pulled out while album banners, numbers
+and source-ref noise are rejected — and that nothing ever raises.
+"""
+
+from core import progress_parse as p
+
+
+# ── Title extraction ──────────────────────────────────────────────────────
+
+def test_extract_title_quoted_and_unquoted_track_forms():
+    assert p.extract_track_title("Downloading track 'Good Life'") == "Good Life"
+    assert p.extract_track_title('Downloading track "Good Life"') == "Good Life"
+    assert p.extract_track_title("Downloading track Good Life") == "Good Life"
+
+
+def test_extract_title_bare_downloading_form():
+    # The raw output the issue describes: "Downloading Good Life".
+    assert p.extract_track_title("Downloading Good Life") == "Good Life"
+
+
+def test_extract_title_strips_log_prefix_and_trackpy_noise():
+    assert p.extract_track_title(
+        "INFO  Downloading track 'Aerodynamic' track.py:212") == "Aerodynamic"
+    assert p.extract_track_title(
+        "[12:00:01] Downloading track 'Veridis Quo'") == "Veridis Quo"
+
+
+def test_extract_title_rejects_album_and_playlist_banners():
+    assert p.extract_track_title("Downloading album 'Discovery'") is None
+    assert p.extract_track_title("Downloading playlist 'Road Trip'") is None
+    # "Downloading <Album> ────────" header form.
+    assert p.extract_track_title("Downloading Discovery ────────────") is None
+
+
+def test_extract_title_rejects_numbers_urls_and_empty():
+    assert p.extract_track_title("Downloading 1") is None
+    assert p.extract_track_title("Downloading track 1 of 12") is None
+    assert p.extract_track_title("Downloading https://x/y") is None
+    assert p.extract_track_title("Nothing relevant here") is None
+
+
+def test_extract_title_never_raises_on_bad_input():
+    assert p.extract_track_title(None) is None
+    assert p.extract_track_title("") is None
+
+
+# ── Track number / done / speed / total ───────────────────────────────────
+
+def test_extract_track_number_only_standalone_lines():
+    assert p.extract_track_number("Track 1") == 1
+    assert p.extract_track_number("  track 12  ") == 12
+    assert p.extract_track_number("Track Download Done") is None
+    assert p.extract_track_number("Track 3: Aerodynamic") is None
+
+
+def test_line_is_track_done():
+    assert p.line_is_track_done("Track Download Done")
+    assert p.line_is_track_done("INFO  track download done")
+    assert not p.line_is_track_done("Downloading track 'x'")
+    assert not p.line_is_track_done(None)
+
+
+def test_extract_speed():
+    assert p.extract_speed("downloading at 1.23 MB/s now") == "1.23 MB/s"
+    assert p.extract_speed("512 KB/s") == "512 KB/s"
+    assert p.extract_speed("no speed here") is None
+
+
+def test_extract_track_total_is_strict():
+    assert p.extract_track_total("Tracks: 14") == 14
+    assert p.extract_track_total("Found 9 tracks") == 9
+    # A "Downloading track 1" line must not be read as a total of 1.
+    assert p.extract_track_total("Downloading track 1") is None
+    assert p.extract_track_total("Tracks: 0") is None
+
+
+# ── Normalisation ─────────────────────────────────────────────────────────
+
+def test_normalize_title_matches_cosmetic_differences():
+    assert p.normalize_title("  'Good   Life' ") == "good life"
+    assert p.normalize_title("Good Life.") == "good life"
+    assert p.normalize_title(None) == ""
+    assert (p.normalize_title("Aerodynamic")
+            == p.normalize_title("aerodynamic"))


### PR DESCRIPTION
## Summary

The visible download area used to show only streamrip's raw terminal output (repeating lines like `Track 1`, `Downloading Good Life`, progress text). This adds a polished, scannable **per-track progress view** as the default tab, while keeping the raw log a click away for debugging.

This is a focused UI/progress change. It is **observational only** — the streamrip download pipeline, the protected metadata sidebar, and the queue/history behavior are untouched.

## What changed in the progress UI

- **New `Progress` tab (now the default view)** with one row per track:
  - track number, title, artist (subtitle)
  - a colored **status badge**: `Queued` / `Downloading` / `Complete` / `Skipped` / `Error`
  - a per-track **progress bar** (pulses while active, green when done, red on error, grey when skipped)
  - a detail line showing **speed** while downloading, **elapsed time** when complete, or the **result / error** otherwise
- An **overall summary banner** shows live progress (`Downloading… 3/12 complete`) and ends in a clear state:
  - ✅ success — `All N tracks downloaded.`
  - ⚠ partial — `8/12 complete · 2 skipped · 2 errors — details in Raw Log.`
  - ❌ failed / invalid URL — points to the Raw Log
- Modern dark styling matching Auryn's teal (`#14B8A6`) / dark identity: aligned columns, status colors, rounded rows.

## How raw logs are still available

- The old `Log` tab is renamed **`Raw Log`** and still receives the **full, unmodified** streamrip output.
- It remains **copyable** (the existing *Copy Log* button is unchanged) and stays the debugging source of truth. Error summaries still render there.
- The progress view is the default tab; the Raw Log is one click away.

## How metadata is used for track titles

- A new GTK-free `core.download_session` model is **seeded from the album/playlist metadata Auryn already resolves** (`core.metadata.deezer_album_tracks` / `qobuz_album_tracks`), so **real song titles appear in order before streamrip prints anything**.
- When metadata is unavailable (single tracks, playlists, TIDAL/SoundCloud), it **falls back to safely parsing streamrip output** via the new GTK-free `core.progress_parse` helpers — never depending only on raw terminal text when better metadata exists.
- The model is fed the **same cleaned lines** the existing log pump emits and reuses `core.streamrip_status` for done/skip/error/finished classification, so **the structured outcome can never disagree with the headline outcome** — a clean "complete" is never shown when errors were detected.

## Validation results

- `python3 -m py_compile src/Auryn.py` → **OK**
- `pytest` → **197 passed** (incl. new `test_download_session.py`, `test_progress_parse.py`, and extended `test_metadata.py`)
- `flake8 . --select=E9,F63,F7,F82` (the build-critical gate) → **0**
- End-to-end model simulation of realistic Deezer-style transcripts (clean run, partial-with-error, and the parse-only `Track 1` / `Downloading Good Life` fallback) produces the expected per-track states.

> Note: the GTK GUI itself could not be launched in the CI sandbox (no PyGObject), so visual rendering was verified by code review + the comprehensive unit tests and the model simulation rather than a live screenshot.

## Confirmation: download logic was not intentionally changed

- The streamrip subprocess handling (`_run_download` / `_run_download_windows`), the `Track Download Done` counter, the main progress bar, and the post-download library organisation are **unchanged**.
- The protected right-side sidebar (cover, album artist, album title, quality, total tracks, UPC, release date) and its `_apply_*_meta` / `_set_meta` paths are **untouched**; `core.metadata` changes are **purely additive**.
- Deezer, Qobuz, and Windows paths all still feed the same view and finish through the existing `_finish` flow.
- The only non-additive edit in `Auryn.py` is renaming a local `outcome` → `final_outcome` in `_finish` to thread it into the new view.


---
_Generated by [Claude Code](https://claude.ai/code/session_01J8BL1EzL7dDBn9hHke383j)_