### PR TITLE
Centralize version handling and derive release builds from the tag

### DIFF
--- a/.github/workflows/linux-packages.yml
+++ b/.github/workflows/linux-packages.yml
@@ -11,8 +11,9 @@ name: Linux packages
 #
 # Versioning:
 #   - On a `v<X.Y.Z>` tag, the package version is `<X.Y.Z>`.
-#   - Otherwise we read APP_VERSION from src/Auryn.py.
-#   The resolved version is also baked into the installed Auryn.py so that
+#   - Otherwise we use BASE_VERSION from the canonical source, src/core/version.py.
+#   Both are resolved by `python3 src/core/version.py --build-version`.
+#   The resolved version is baked into the installed core/version.py so that
 #   `auryn --version` matches the package metadata.
 
 on:
@@ -35,13 +36,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - id: resolve
-        name: Resolve version from tag or APP_VERSION
+        name: Resolve version from tag or canonical source
+        # core.version reads GITHUB_REF/GITHUB_REF_NAME to detect a tag build
+        # and otherwise falls back to BASE_VERSION, so this single call covers
+        # tag, push and PR builds without duplicating the strip-"v" logic.
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/v}"
-          else
-            VERSION="$(grep -E '^APP_VERSION\s*=' src/Auryn.py | head -n1 | cut -d'"' -f2)"
-          fi
+          VERSION="$(python3 src/core/version.py --build-version)"
           if [ -z "${VERSION}" ]; then
             echo "Could not resolve version" >&2
             exit 1
@@ -65,7 +65,7 @@ jobs:
             lintian
 
       - name: Sanity-check sources (py_compile)
-        run: python3 -m py_compile src/Auryn.py
+        run: python3 -m py_compile src/Auryn.py src/core/version.py
 
       - name: Build .deb
         run: packaging/debian/build-deb.sh "${{ needs.version.outputs.version }}"
@@ -89,18 +89,18 @@ jobs:
             echo "Expected Architecture: all, got: ${arch}" >&2
             exit 1
           fi
-          # The build script bakes APP_VERSION into the installed Auryn.py.
-          # Extract it from the package and confirm it matches the resolved version.
+          # The build script bakes _BAKED_VERSION into the installed
+          # core/version.py. Extract it and confirm it matches the resolved version.
           tmp="$(mktemp -d)"
           dpkg-deb -x "${pkg}" "${tmp}"
-          baked="$(grep -E '^APP_VERSION\s*=' "${tmp}/usr/share/auryn/Auryn.py" \
+          baked="$(grep -E '^_BAKED_VERSION\s*=' "${tmp}/usr/share/auryn/core/version.py" \
                    | head -n1 | cut -d'"' -f2)"
           want="${{ needs.version.outputs.version }}"
           if [ "${baked}" != "${want}" ]; then
-            echo "Baked APP_VERSION (${baked}) does not match package version (${want})" >&2
+            echo "Baked _BAKED_VERSION (${baked}) does not match package version (${want})" >&2
             exit 1
           fi
-          echo "OK: .deb Architecture=all, APP_VERSION=${baked}"
+          echo "OK: .deb Architecture=all, baked version=${baked}"
 
       - name: Lint .deb (informational)
         run: lintian --no-tag-display-limit dist/*.deb || true
@@ -128,7 +128,7 @@ jobs:
             rpmlint
 
       - name: Sanity-check sources (py_compile)
-        run: python3 -m py_compile src/Auryn.py
+        run: python3 -m py_compile src/Auryn.py src/core/version.py
 
       - name: Build .rpm
         run: packaging/rpm/build-rpm.sh "${{ needs.version.outputs.version }}"
@@ -152,19 +152,19 @@ jobs:
             echo "Expected ARCH: noarch, got: ${arch}" >&2
             exit 1
           fi
-          # Extract the bundled Auryn.py from the .rpm and confirm the
-          # baked APP_VERSION matches the resolved package version.
+          # Extract the bundled core/version.py from the .rpm and confirm the
+          # baked _BAKED_VERSION matches the resolved package version.
           tmp="$(mktemp -d)"
           ( cd "${tmp}" && rpm2cpio "${GITHUB_WORKSPACE}/${pkg}" \
               | cpio -idm --quiet )
-          baked="$(grep -E '^APP_VERSION\s*=' "${tmp}/usr/share/auryn/Auryn.py" \
+          baked="$(grep -E '^_BAKED_VERSION\s*=' "${tmp}/usr/share/auryn/core/version.py" \
                    | head -n1 | cut -d'"' -f2)"
           want="${{ needs.version.outputs.version }}"
           if [ "${baked}" != "${want}" ]; then
-            echo "Baked APP_VERSION (${baked}) does not match package version (${want})" >&2
+            echo "Baked _BAKED_VERSION (${baked}) does not match package version (${want})" >&2
             exit 1
           fi
-          echo "OK: .rpm ARCH=noarch, APP_VERSION=${baked}"
+          echo "OK: .rpm ARCH=noarch, baked version=${baked}"
 
       - name: Lint .rpm (informational)
         run: rpmlint dist/*.rpm || true

--- a/.github/workflows/windows-exe.yml
+++ b/.github/workflows/windows-exe.yml
@@ -26,9 +26,11 @@ name: Windows packaging (experimental)
 #
 # Versioning mirrors the Linux workflow:
 #   - On a v<X.Y.Z> tag, the resolved version is <X.Y.Z>.
-#   - Otherwise we read APP_VERSION from src/Auryn.py.
-# That value is baked into the bundled Auryn.py so the produced artifact
-# reports the matching version.
+#   - Otherwise we use BASE_VERSION from the canonical source, src/core/version.py.
+# That value is baked into the bundled core/version.py so the produced artifact
+# reports the matching version. (This step runs in Git Bash before the MSYS2
+# Python is installed, so it resolves the source version with grep rather than
+# the core.version CLI used by the Linux workflow.)
 
 on:
   push:
@@ -65,7 +67,7 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
           else
-            VERSION="$(grep -E '^APP_VERSION\s*=' src/Auryn.py | head -n1 | cut -d'"' -f2)"
+            VERSION="$(grep -E '^BASE_VERSION\s*=' src/core/version.py | head -n1 | cut -d'"' -f2)"
           fi
           if [ -z "${VERSION}" ]; then
             echo "Could not resolve version" >&2
@@ -177,18 +179,18 @@ jobs:
           done
 
       - name: Sanity-check sources (py_compile)
-        run: python -m py_compile src/Auryn.py
+        run: python -m py_compile src/Auryn.py src/core/version.py
 
-      - name: Bake APP_VERSION into src/Auryn.py
+      - name: Bake resolved version into src/core/version.py
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          sed -i -E "s|^APP_VERSION\s*=.*|APP_VERSION = \"${VERSION}\"|" src/Auryn.py
-          baked="$(grep -E '^APP_VERSION\s*=' src/Auryn.py | head -n1 | cut -d'"' -f2)"
+          sed -i -E "s|^_BAKED_VERSION\s*=.*|_BAKED_VERSION = \"${VERSION}\"|" src/core/version.py
+          baked="$(grep -E '^_BAKED_VERSION\s*=' src/core/version.py | head -n1 | cut -d'"' -f2)"
           if [ "${baked}" != "${VERSION}" ]; then
-            echo "Bake failed: source reports APP_VERSION=${baked}, want=${VERSION}" >&2
+            echo "Bake failed: source reports _BAKED_VERSION=${baked}, want=${VERSION}" >&2
             exit 1
           fi
-          echo "OK: src/Auryn.py now reports APP_VERSION=${baked}"
+          echo "OK: src/core/version.py now reports _BAKED_VERSION=${baked}"
 
       - name: Build --onedir bundle with PyInstaller (experimental)
         id: build_onedir

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -19,50 +19,60 @@ streamrip for the current user via `pip install --user streamrip`
 
 ## Single source of truth for the version
 
-The application version is defined **once**, in `src/Auryn.py`:
+The project version lives in **one** place, `src/core/version.py`:
 
 ```python
-APP_VERSION = "0.1.1"
+BASE_VERSION = "0.2.10"
 ```
 
-Everything else derives from it:
+Everything else derives from three small, tested helpers in that module:
 
-- `auryn --version` prints `Auryn <APP_VERSION>`
-- The About dialog uses `APP_VERSION`
-- `packaging/debian/build-deb.sh` and `packaging/rpm/build-rpm.sh` read
-  `APP_VERSION` when no version argument is passed
-- CI passes the resolved version (see below) to the build scripts, which
-  then **bake** that value into the installed `Auryn.py` so the running
-  app and the package metadata always match
+- `get_app_version()` — the string shown in the UI, About dialog and
+  `auryn --version` / `--doctor`. Release builds report the bare tag
+  version (e.g. `0.2.10`); local/PR builds report `<BASE_VERSION>-dev`
+  (e.g. `0.2.10-dev`) so a non-release build is obvious.
+- `get_build_version()` — the bare version used for package metadata and
+  artifact names. Never carries the `-dev` suffix and is always valid for
+  Debian / RPM / Windows.
+- `normalize_release_tag()` — turns a tag like `v0.1.4` into `0.1.4`
+  (and rejects junk, falling back to a safe default).
 
-You should never need to edit a version string in more than one place.
+`src/Auryn.py` sets `APP_VERSION = get_app_version()`; the window title,
+header badge and footer are stamped at runtime, so no version string is
+ever hardcoded in `Auryn.py` or `Auryn.ui`.
+
+You should never need to edit a version string in more than one place:
+bump `BASE_VERSION`, or just push a tag.
 
 ## How CI resolves the version
 
-The `version` job in `linux-packages.yml`:
+The `version` job in `linux-packages.yml` runs
+`python3 src/core/version.py --build-version`, which:
 
-- On a tag push matching `v*` (e.g. `v2.0.0`) → version is `2.0.0`
-- On any other push / PR → version is the current `APP_VERSION` from
-  `src/Auryn.py`
+- On a tag push matching `v*` (e.g. `v2.0.0`) → resolves to `2.0.0`
+  (via `GITHUB_REF` / `GITHUB_REF_NAME`)
+- On any other push / PR → resolves to `BASE_VERSION`
 
-That value is then passed to both `build-deb.sh` and `build-rpm.sh`,
-which:
+That value is passed to both `build-deb.sh` and `build-rpm.sh`, which:
 
 1. Use it as the package `Version:` field, and
-2. Rewrite `APP_VERSION` in the bundled `usr/share/auryn/Auryn.py`
-   before packaging.
+2. **Bake** it into `_BAKED_VERSION` in the bundled
+   `usr/share/auryn/core/version.py` before packaging — so the installed
+   app reports the release version at runtime even though no GitHub
+   environment variables exist on the user's machine.
 
 So a `v2.0.0` tag build produces `auryn_2.0.0_all.deb` /
 `auryn-2.0.0-1.noarch.rpm`, and `auryn --version` from those packages
-prints `Auryn 2.0.0` — even if `APP_VERSION` in `main` still says
-`0.1.1` at the time of the tag.
+prints `Auryn 2.0.0` — even if `BASE_VERSION` in `main` still says
+`0.2.10` at the time of the tag. The Windows workflow mirrors this and
+bakes the same `_BAKED_VERSION`.
 
 ## Release flow
 
 1. Decide the release version, e.g. `2.0.0`.
-2. (Optional but recommended) Bump `APP_VERSION` in `src/Auryn.py`,
-   commit, and push to `main`. This keeps the dev branch's
-   `--version` honest.
+2. (Optional but recommended) Bump `BASE_VERSION` in
+   `src/core/version.py`, commit, and push to `main`. This keeps the dev
+   branch's `--version` honest (it will read `2.0.0-dev`).
 3. Tag the commit and push the tag:
 
    ```sh
@@ -86,10 +96,10 @@ prints `Auryn 2.0.0` — even if `APP_VERSION` in `main` still says
 ## Local builds
 
 You don't need a tag to build locally — the scripts work on any
-checkout:
+checkout and resolve the version from `src/core/version.py`:
 
 ```sh
-packaging/debian/build-deb.sh            # uses APP_VERSION from src/Auryn.py
+packaging/debian/build-deb.sh            # uses BASE_VERSION from core.version
 packaging/debian/build-deb.sh 2.0.0-dev  # explicit override
 
 packaging/rpm/build-rpm.sh

--- a/packaging/debian/build-deb.sh
+++ b/packaging/debian/build-deb.sh
@@ -4,8 +4,8 @@
 # Usage:
 #   packaging/debian/build-deb.sh [VERSION]
 #
-# If VERSION is not provided, it is extracted from src/Auryn.py (APP_VERSION).
-# The resulting .deb is written to dist/.
+# If VERSION is not provided, it is resolved from the canonical version source
+# (src/core/version.py). The resulting .deb is written to dist/.
 
 set -euo pipefail
 
@@ -15,11 +15,13 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 cd "${REPO_ROOT}"
 
 # --- Resolve version -------------------------------------------------------
-# Priority: explicit arg > APP_VERSION in src/Auryn.py > fallback.
-# To bump the package version, update APP_VERSION in src/Auryn.py.
+# Priority: explicit arg > canonical source (core.version) > fallback.
+# To bump the package version, update BASE_VERSION in src/core/version.py.
+# core.version resolves a release tag from the environment when present, so on
+# a tag build this yields the release version even without an explicit arg.
 VERSION="${1:-}"
 if [ -z "${VERSION}" ]; then
-    VERSION="$(grep -E '^APP_VERSION\s*=' src/Auryn.py | head -n1 | cut -d'"' -f2 || true)"
+    VERSION="$(python3 src/core/version.py --build-version 2>/dev/null || true)"
 fi
 VERSION="${VERSION:-0.0.0}"
 
@@ -43,15 +45,17 @@ done
 
 # Python sources
 install -m 0644 src/Auryn.py "${PKG_ROOT}/usr/share/auryn/Auryn.py"
-# Bake the resolved version into the installed Auryn.py so that
-# `auryn --version` and the About dialog report the same version as the
-# package metadata (especially on tag builds where VERSION comes from the tag).
-sed -i -E "s|^APP_VERSION\s*=.*|APP_VERSION = \"${VERSION}\"|" \
-    "${PKG_ROOT}/usr/share/auryn/Auryn.py"
 install -m 0644 src/Auryn.ui "${PKG_ROOT}/usr/share/auryn/Auryn.ui"
 install -m 0644 src/core/__init__.py "${PKG_ROOT}/usr/share/auryn/core/__init__.py"
 install -m 0644 src/core/errors.py "${PKG_ROOT}/usr/share/auryn/core/errors.py"
 install -m 0644 src/core/status.py "${PKG_ROOT}/usr/share/auryn/core/status.py"
+install -m 0644 src/core/version.py "${PKG_ROOT}/usr/share/auryn/core/version.py"
+# Bake the resolved version into the installed core/version.py so that
+# `auryn --version`, the About dialog and the window title all report the same
+# version as the package metadata (especially on tag builds where VERSION
+# comes from the release tag and no GitHub env vars exist at runtime).
+sed -i -E "s|^_BAKED_VERSION\s*=.*|_BAKED_VERSION = \"${VERSION}\"|" \
+    "${PKG_ROOT}/usr/share/auryn/core/version.py"
 
 # Desktop entry (already present in repo)
 install -m 0644 desktop/Auryn.desktop "${PKG_ROOT}/usr/share/applications/Auryn.desktop"

--- a/packaging/rpm/auryn.spec
+++ b/packaging/rpm/auryn.spec
@@ -1,11 +1,12 @@
 # RPM spec for Auryn — GTK GUI for streamrip.
 #
-# The package version defaults to APP_VERSION in src/Auryn.py and can be
-# overridden at build time:
-#   rpmbuild -bb --define "auryn_version 0.1.1" --define "_sourcedir $PWD" packaging/rpm/auryn.spec
+# The package version is supplied via --define "auryn_version X.Y.Z" (the
+# build-rpm.sh wrapper resolves it from the canonical source, src/core/version.py,
+# or from a release tag). Example:
+#   rpmbuild -bb --define "auryn_version 0.2.10" --define "_sourcedir $PWD" packaging/rpm/auryn.spec
 #
-# To bump the package version, update APP_VERSION in src/Auryn.py (or pass
-# --define "auryn_version X.Y.Z" on the command line / via the workflow).
+# To bump the package version, update BASE_VERSION in src/core/version.py (or
+# pass --define "auryn_version X.Y.Z" on the command line / via the workflow).
 
 %{!?auryn_version: %define auryn_version 0.0.0}
 
@@ -57,14 +58,16 @@ done
 
 # Python sources
 install -m 0644 %{_sourcedir}/src/Auryn.py        %{buildroot}%{_datadir}/auryn/Auryn.py
-# Bake the resolved version into the installed Auryn.py so that
-# `auryn --version` and the About dialog match the package metadata.
-sed -i -E "s|^APP_VERSION\s*=.*|APP_VERSION = \"%{auryn_version}\"|" \
-    %{buildroot}%{_datadir}/auryn/Auryn.py
 install -m 0644 %{_sourcedir}/src/Auryn.ui        %{buildroot}%{_datadir}/auryn/Auryn.ui
 install -m 0644 %{_sourcedir}/src/core/__init__.py %{buildroot}%{_datadir}/auryn/core/__init__.py
 install -m 0644 %{_sourcedir}/src/core/errors.py  %{buildroot}%{_datadir}/auryn/core/errors.py
 install -m 0644 %{_sourcedir}/src/core/status.py  %{buildroot}%{_datadir}/auryn/core/status.py
+install -m 0644 %{_sourcedir}/src/core/version.py %{buildroot}%{_datadir}/auryn/core/version.py
+# Bake the resolved version into the installed core/version.py so that
+# `auryn --version`, the About dialog and the window title match the package
+# metadata (no GitHub env vars exist on the user's machine at runtime).
+sed -i -E "s|^_BAKED_VERSION\s*=.*|_BAKED_VERSION = \"%{auryn_version}\"|" \
+    %{buildroot}%{_datadir}/auryn/core/version.py
 
 # Desktop entry
 install -m 0644 %{_sourcedir}/desktop/Auryn.desktop \
@@ -96,6 +99,7 @@ ln -s Auryn %{buildroot}%{_bindir}/auryn
 %{_datadir}/auryn/core/__init__.py
 %{_datadir}/auryn/core/errors.py
 %{_datadir}/auryn/core/status.py
+%{_datadir}/auryn/core/version.py
 %{_datadir}/applications/Auryn.desktop
 %{_datadir}/icons/hicolor/scalable/apps/Auryn.svg
 %{_datadir}/icons/hicolor/16x16/apps/Auryn.png

--- a/packaging/rpm/build-rpm.sh
+++ b/packaging/rpm/build-rpm.sh
@@ -4,8 +4,8 @@
 # Usage:
 #   packaging/rpm/build-rpm.sh [VERSION]
 #
-# If VERSION is not provided, it is extracted from src/Auryn.py (APP_VERSION).
-# The resulting .rpm is written to dist/.
+# If VERSION is not provided, it is resolved from the canonical version source
+# (src/core/version.py). The resulting .rpm is written to dist/.
 
 set -euo pipefail
 
@@ -16,7 +16,7 @@ cd "${REPO_ROOT}"
 
 VERSION="${1:-}"
 if [ -z "${VERSION}" ]; then
-    VERSION="$(grep -E '^APP_VERSION\s*=' src/Auryn.py | head -n1 | cut -d'"' -f2 || true)"
+    VERSION="$(python3 src/core/version.py --build-version 2>/dev/null || true)"
 fi
 VERSION="${VERSION:-0.0.0}"
 

--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Auryn v0.1.1 — GUI wrapper for streamrip
+Auryn — GUI wrapper for streamrip
 © 2025 TheZupZup — GNU GPL v3
 UI chargée depuis Auryn.ui (Glade)
 """
@@ -34,9 +34,13 @@ from core import deezer
 from core import library
 from core import quality as qual
 from core import streamrip_exec
+from core import version as _version
 
 APP_NAME = "Auryn"
-APP_VERSION = "0.1.1"
+# Resolved from the single source of truth in core.version: the canonical
+# BASE_VERSION for dev builds (shown as "<base>-dev"), or the GitHub release
+# tag for tagged/packaged builds. Never edit a version string here.
+APP_VERSION = _version.get_app_version()
 
 SYSTEM_NAME = platform.system()
 IS_WINDOWS = SYSTEM_NAME == "Windows"
@@ -393,6 +397,7 @@ def run_doctor(verbose=False):
     whether the bundled streamrip was found, the streamrip config path and
     whether Deezer is configured — all without ever exposing the ARL.
     """
+    print(f"INFO  {APP_NAME} version: {APP_VERSION}")
     rip_search_paths = [
         os.path.expanduser("~/.local/bin/rip"),
         "/usr/local/bin/rip",
@@ -534,6 +539,11 @@ class AurynApp:
         self.btn_clear_queue     = self.builder.get_object("btn_clear_queue")
         self.queue_listbox       = self.builder.get_object("queue_listbox")
         self.queue_empty_label   = self.builder.get_object("queue_empty_label")
+
+        # Stamp the resolved version onto the title, header badge and footer.
+        # The .ui ships version-neutral placeholders; core.version is the single
+        # source of truth, so these are filled in at runtime.
+        self._apply_version_labels()
 
         # ── Checkbuttons qualité ──
         self._quality_checks = [
@@ -4494,6 +4504,26 @@ class AurynApp:
         except Exception:
             pass
 
+    def _apply_version_labels(self):
+        """Fill the title, header badge and footer with the resolved version.
+
+        APP_VERSION (from core.version) is the single source of truth, so every
+        surface is stamped here rather than hardcoded in the .ui file. Version
+        strings only ever contain [0-9A-Za-z.-], so embedding them in Pango
+        markup needs no escaping.
+        """
+        ver = APP_VERSION
+        if self.window is not None:
+            self.window.set_title(f"{APP_NAME} v{ver}")
+        version_lbl = self.builder.get_object("version_label")
+        if version_lbl is not None:
+            version_lbl.set_markup(
+                f'<span foreground="#555555" size="small">v{ver}</span>')
+        if self.footer_lbl is not None:
+            self.footer_lbl.set_markup(
+                f'<span foreground="#444444" size="small">  {APP_NAME} '
+                f'v{ver}  ·  streamrip GUI</span>')
+
     def _show_about(self, *_):
         dlg = Gtk.AboutDialog()
         dlg.set_transient_for(self.window)
@@ -4519,7 +4549,7 @@ class AurynApp:
             q_track = urllib.parse.quote(track)
             url = f"https://lrclib.net/api/get?artist_name={q_artist}&track_name={q_track}"
             
-            req = urllib.request.Request(url, headers={"User-Agent": "Auryn/0.1.1 (GTK3)"})
+            req = urllib.request.Request(url, headers={"User-Agent": f"Auryn/{APP_VERSION} (GTK3)"})
             with urllib.request.urlopen(req, timeout=10) as r:
                 data = json.loads(r.read().decode())
                 

--- a/src/Auryn.ui
+++ b/src/Auryn.ui
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.40.0 -->
-<!-- Generated for Auryn v0.1.1 — Edit with Glade -->
+<!-- Auryn UI — Edit with Glade. Version text is set at runtime (core.version). -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkWindow" id="main_window">
     <property name="can-focus">False</property>
-    <property name="title">Auryn v0.1.1</property>
+    <property name="title">Auryn</property>
     <property name="default-width">920</property>
     <property name="default-height">590</property>
     <child>
@@ -34,7 +34,7 @@
                 <property name="can-focus">False</property>
                 <property name="valign">end</property>
                 <property name="margin-bottom">3</property>
-                <property name="label">&lt;span foreground="#555555" size="small"&gt;v0.1.1&lt;/span&gt;</property>
+                <property name="label">&lt;span foreground="#555555" size="small"&gt;&lt;/span&gt;</property>
                 <property name="use-markup">True</property>
               </object>
               <packing>
@@ -1045,7 +1045,7 @@
               <object class="GtkLabel" id="footer_lbl">
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="label">&lt;span foreground="#444444" size="small"&gt;  Auryn v0.1.1  ·  streamrip GUI&lt;/span&gt;</property>
+                <property name="label">&lt;span foreground="#444444" size="small"&gt;  Auryn  ·  streamrip GUI&lt;/span&gt;</property>
                 <property name="use-markup">True</property>
               </object>
               <packing>

--- a/src/core/version.py
+++ b/src/core/version.py
@@ -1,0 +1,143 @@
+"""Single source of truth for Auryn's version.
+
+The canonical project version is :data:`BASE_VERSION` below. Everything that
+shows or records a version — the window title, the header badge, the footer,
+the About dialog, ``--version`` / ``--doctor`` output, and the Debian / RPM /
+Windows package metadata — derives from this module, so there is exactly one
+place to bump the version for a normal source release.
+
+Release builds never need a manual source edit. When GitHub Actions builds
+from a ``v<X.Y.Z>`` tag the tag drives the version:
+
+* the workflows resolve it (``python3 src/core/version.py --build-version`` on
+  Linux, or reading ``GITHUB_REF`` directly), and
+* the packaging step bakes the resolved value into :data:`_BAKED_VERSION`
+  here, so the installed artifact reports the release version at runtime even
+  though no GitHub environment variables exist on the user's machine.
+
+Pull-request and ordinary ``main`` builds are never treated as releases: with
+no tag they fall back to ``<BASE_VERSION>-dev`` for display.
+"""
+
+import os
+import re
+
+# ── Canonical source version ────────────────────────────────────────────────
+# Bump this for a normal dev/source release. It is the only hardcoded version
+# string in the project; release tags override it automatically (see below).
+BASE_VERSION = "0.2.10"
+
+# Suffix appended to BASE_VERSION for non-release (local / PR / push) builds so
+# it is obvious a build did not come from a tagged GitHub Release.
+DEV_SUFFIX = "dev"
+
+# Baked at build time by the release tooling: a sed in the packaging scripts /
+# workflows replaces the empty string below with the resolved tag version.
+# When set to a valid version it is authoritative and used verbatim (no -dev
+# suffix), so installed packages report their real release version at runtime.
+_BAKED_VERSION = ""
+
+# A package version is a small set of dotted numeric components, optionally
+# followed by short alphanumeric pre-release/build segments. This is the common
+# subset that is simultaneously valid for Debian, RPM and Windows artifact
+# names, so any value that matches is safe to use everywhere.
+_VERSION_RE = re.compile(r"^[0-9]+(?:\.[0-9]+)*(?:[-.][0-9A-Za-z]+)*$")
+
+
+def normalize_release_tag(tag):
+    """Convert a git/release tag into a bare package version.
+
+    Strips a single leading ``v``/``V`` plus surrounding whitespace, then
+    validates the result::
+
+        normalize_release_tag("v0.1.4")  -> "0.1.4"
+        normalize_release_tag("0.1.4")   -> "0.1.4"
+        normalize_release_tag("  V1.2 ") -> "1.2"
+
+    Returns ``None`` for empty, ``None`` or syntactically invalid tags so the
+    caller can fall back to a safe default.
+    """
+    if not tag or not isinstance(tag, str):
+        return None
+    tag = tag.strip()
+    if tag[:1] in ("v", "V"):
+        tag = tag[1:].strip()
+    if not tag or not _VERSION_RE.match(tag):
+        return None
+    return tag
+
+
+def _tag_from_env():
+    """Resolve a release version from the build environment, or ``None``.
+
+    Precedence:
+
+    1. ``AURYN_VERSION`` — explicit override set by the release tooling.
+    2. ``GITHUB_REF_NAME`` / ``GITHUB_REF`` — but only when the ref is a tag,
+       so branch and pull-request builds never look like releases.
+    """
+    explicit = normalize_release_tag(os.environ.get("AURYN_VERSION"))
+    if explicit:
+        return explicit
+    if os.environ.get("GITHUB_REF", "").startswith("refs/tags/"):
+        ref_name = (os.environ.get("GITHUB_REF_NAME")
+                    or os.environ["GITHUB_REF"].split("/", 2)[-1])
+        return normalize_release_tag(ref_name)
+    return None
+
+
+def get_build_version():
+    """Bare version for package metadata and artifact names (no leading ``v``).
+
+    Resolution order: baked release value, then a tag in the environment, then
+    :data:`BASE_VERSION`. The result is always a Debian/RPM/Windows-safe
+    version string and never carries the ``-dev`` suffix.
+    """
+    baked = normalize_release_tag(_BAKED_VERSION)
+    if baked:
+        return baked
+    return _tag_from_env() or BASE_VERSION
+
+
+def get_app_version():
+    """Version string for display (window title, footer, About, ``--version``).
+
+    Release builds (a baked value or a tag in the environment) report the bare
+    version, e.g. ``0.1.4``. Everything else reports ``<BASE_VERSION>-dev``,
+    e.g. ``0.2.10-dev``, to make non-release builds obvious.
+    """
+    baked = normalize_release_tag(_BAKED_VERSION)
+    if baked:
+        return baked
+    tag = _tag_from_env()
+    if tag:
+        return tag
+    return f"{BASE_VERSION}-{DEV_SUFFIX}"
+
+
+def _main(argv):
+    """Tiny CLI so shell tooling resolves versions without duplicating logic.
+
+        python3 src/core/version.py --build-version   # package/artifact version
+        python3 src/core/version.py --app-version      # display version
+        python3 src/core/version.py --base-version     # raw BASE_VERSION
+        python3 src/core/version.py                     # same as --app-version
+    """
+    arg = argv[1] if len(argv) > 1 else "--app-version"
+    if arg in ("--build-version", "-b"):
+        print(get_build_version())
+    elif arg in ("--app-version", "-a"):
+        print(get_app_version())
+    elif arg == "--base-version":
+        print(BASE_VERSION)
+    else:
+        import sys
+        print("usage: version.py [--build-version|--app-version|--base-version]",
+              file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+    raise SystemExit(_main(sys.argv))

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,138 @@
+"""Tests for the central version source of truth (``core.version``).
+
+These guard the rule that Auryn shows one version everywhere and that GitHub
+release tags (``v0.1.4``) drive the app/package version automatically, while
+local and pull-request builds stay on a safe ``-dev`` version. The module is
+GTK-free so these run under plain ``pytest`` without importing the application.
+"""
+
+import re
+
+import pytest
+
+from core import version as v
+
+
+# Environment variables that influence version resolution. They are cleared
+# before each test so results are deterministic regardless of where pytest
+# runs (CI sets GITHUB_REF). The bake slot is reset too, in case the tests run
+# against a packaged checkout where it was filled in.
+_ENV_KEYS = ("AURYN_VERSION", "GITHUB_REF", "GITHUB_REF_NAME")
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for key in _ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(v, "_BAKED_VERSION", "")
+
+
+# ── normalize_release_tag ───────────────────────────────────────────────────
+
+def test_normalize_strips_leading_v():
+    assert v.normalize_release_tag("v0.1.4") == "0.1.4"
+
+
+def test_normalize_passes_through_bare_version():
+    assert v.normalize_release_tag("0.1.4") == "0.1.4"
+
+
+def test_normalize_handles_uppercase_v_and_whitespace():
+    assert v.normalize_release_tag("  V1.2  ") == "1.2"
+
+
+def test_normalize_two_component_tag():
+    assert v.normalize_release_tag("v0.2") == "0.2"
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["", "   ", "v", "vv1.2", "nightly", "1.2.3-", "release-1", "1..2",
+     None, 1.2],
+)
+def test_normalize_invalid_returns_none(bad):
+    assert v.normalize_release_tag(bad) is None
+
+
+# ── local / dev fallback ────────────────────────────────────────────────────
+
+def test_dev_app_version_has_dev_suffix():
+    assert v.get_app_version() == f"{v.BASE_VERSION}-{v.DEV_SUFFIX}"
+
+
+def test_dev_build_version_is_base_without_suffix():
+    assert v.get_build_version() == v.BASE_VERSION
+    assert "dev" not in v.get_build_version()
+
+
+# ── tag builds ──────────────────────────────────────────────────────────────
+
+def test_tag_build_drives_app_and_package_version(monkeypatch):
+    monkeypatch.setenv("GITHUB_REF", "refs/tags/v0.1.4")
+    monkeypatch.setenv("GITHUB_REF_NAME", "v0.1.4")
+    assert v.get_app_version() == "0.1.4"
+    assert v.get_build_version() == "0.1.4"
+
+
+def test_tag_build_without_ref_name_falls_back_to_ref(monkeypatch):
+    monkeypatch.setenv("GITHUB_REF", "refs/tags/v2.3.4")
+    assert v.get_build_version() == "2.3.4"
+
+
+def test_explicit_override_wins(monkeypatch):
+    monkeypatch.setenv("AURYN_VERSION", "v9.9.9")
+    monkeypatch.setenv("GITHUB_REF", "refs/heads/main")
+    assert v.get_app_version() == "9.9.9"
+    assert v.get_build_version() == "9.9.9"
+
+
+# ── PR / branch builds must never look like a release ───────────────────────
+
+def test_pull_request_build_is_not_a_release(monkeypatch):
+    monkeypatch.setenv("GITHUB_REF", "refs/pull/42/merge")
+    monkeypatch.setenv("GITHUB_REF_NAME", "42/merge")
+    assert v.get_app_version() == f"{v.BASE_VERSION}-{v.DEV_SUFFIX}"
+    assert v.get_build_version() == v.BASE_VERSION
+
+
+def test_branch_push_is_not_a_release(monkeypatch):
+    monkeypatch.setenv("GITHUB_REF", "refs/heads/main")
+    assert v.get_app_version().endswith(f"-{v.DEV_SUFFIX}")
+
+
+# ── baked release version (installed packages, no env at runtime) ───────────
+
+def test_baked_version_is_authoritative(monkeypatch):
+    monkeypatch.setattr(v, "_BAKED_VERSION", "0.3.7")
+    assert v.get_app_version() == "0.3.7"
+    assert v.get_build_version() == "0.3.7"
+
+
+def test_baked_version_with_leading_v_is_normalized(monkeypatch):
+    monkeypatch.setattr(v, "_BAKED_VERSION", "v0.3.7")
+    assert v.get_app_version() == "0.3.7"
+
+
+def test_invalid_baked_version_falls_back_to_dev(monkeypatch):
+    monkeypatch.setattr(v, "_BAKED_VERSION", "not-a-version!")
+    assert v.get_app_version() == f"{v.BASE_VERSION}-{v.DEV_SUFFIX}"
+
+
+# ── package-name safety ─────────────────────────────────────────────────────
+# A version must be safe to drop into Debian/RPM/Windows artifact names.
+
+_SAFE_PKG_RE = re.compile(r"^[0-9A-Za-z.+~-]+$")
+
+
+@pytest.mark.parametrize(
+    "ref",
+    [None, "refs/tags/v1.2.3", "refs/heads/main", "refs/pull/9/merge"],
+)
+def test_build_version_is_package_safe(monkeypatch, ref):
+    if ref is not None:
+        monkeypatch.setenv("GITHUB_REF", ref)
+        monkeypatch.setenv("GITHUB_REF_NAME", ref.rsplit("/", 1)[-1])
+    bv = v.get_build_version()
+    assert _SAFE_PKG_RE.match(bv), bv
+    # Debian and RPM versions must begin with a digit.
+    assert bv[0].isdigit()


### PR DESCRIPTION
## Why

The version was hardcoded as `APP_VERSION = "0.1.1"` in `src/Auryn.py` **and** baked into `src/Auryn.ui` (window title, header badge, footer). Those `.ui` strings were never updated by the packaging sed, so the app could show **v0.1.1** while GitHub Releases were at **v0.2.x** — exactly the "stale, unprofessional version" problem. This PR makes the GitHub release/tag the source of truth for builds and removes every duplicated hardcoded version string.

## New source of truth

A single module, **`src/core/version.py`**, owns the version:

```python
BASE_VERSION = "0.2.10"   # bump here for a normal dev release
```

plus three small, tested helpers (and a tiny CLI used by the tooling):

- `normalize_release_tag("v0.1.4") -> "0.1.4"` (strips a leading `v`, validates, rejects junk)
- `get_build_version()` — bare version for package metadata / artifact names (never `-dev`, always Debian/RPM/Windows‑safe)
- `get_app_version()` — version shown in the UI / `--version` / `--doctor`

`src/Auryn.py` now sets `APP_VERSION = get_app_version()` and stamps the title, header badge and footer **at runtime**, so `Auryn.py` and `Auryn.ui` contain no hardcoded version.

## How release tags become app/package versions

| Build | `get_app_version()` | `get_build_version()` (package/artifact) |
|-------|--------------------|------------------------------------------|
| Local / `main` push | `0.2.10-dev` | `0.2.10` |
| Pull request | `0.2.10-dev` | `0.2.10` |
| Tag `v0.1.4` | `0.1.4` | `0.1.4` |

- Tag builds are detected from `GITHUB_REF` / `GITHUB_REF_NAME` (or an explicit `AURYN_VERSION`), and the leading `v` is stripped.
- The release version is **baked** into `_BAKED_VERSION` in the bundled `core/version.py`, so an installed `.deb`/`.rpm`/`.exe` reports the right version at runtime even with no GitHub env vars present.
- PR/branch builds never look like a release (always `-dev`).

## What changed

- **New:** `src/core/version.py`, `tests/test_version.py` (28 tests)
- **`src/Auryn.py`:** import `core.version`; `APP_VERSION = get_app_version()`; runtime `_apply_version_labels()`; `--doctor` prints the version; User‑Agent uses `APP_VERSION`
- **`src/Auryn.ui`:** removed hardcoded `v0.1.1` from title / version badge / footer (filled at runtime)
- **Packaging:** `build-deb.sh`, `build-rpm.sh`, `rpm/auryn.spec` resolve the version from `core.version`, ship `core/version.py`, and bake `_BAKED_VERSION` (was: sed `APP_VERSION` into `Auryn.py`)
- **Workflows:** `linux-packages.yml` resolves via `python3 src/core/version.py --build-version` and verifies the baked value inside the built `.deb`/`.rpm`; `windows-exe.yml` bakes `_BAKED_VERSION` and falls back to `BASE_VERSION` (Git Bash, no Python dependency before MSYS2 is set up). Artifact names / release assets continue to use the resolved version.
- **`packaging/README.md`:** documents the new flow

## Validation

- `python3 -m py_compile src/Auryn.py src/core/version.py` — OK
- `pytest` — **225 passed** (28 new)
- `flake8 --select=E9,F63,F7,F82` (the build‑failing selection) — 0 errors
- `python3 src/Auryn.py --version` → `Auryn 0.2.10-dev`; with `GITHUB_REF=refs/tags/v0.1.4` → `0.1.4`
- `python3 src/Auryn.py --doctor` first line → `INFO  Auryn version: 0.2.10-dev`
- Built a `.deb` locally: no‑arg → `auryn_0.2.10_all.deb`; arg `0.1.4` → `auryn_0.1.4_all.deb`, with `_BAKED_VERSION` matching the package `Version:` and `core/version.py` packaged. The build stages into a temp copy, so the working‑tree source is not mutated.

## Out of scope / non‑goals (confirmed unchanged)

- **Download logic** is untouched.
- **Deezer** and **Qobuz** support untouched.
- **Windows** and **Linux** packaging layouts unchanged apart from version resolution + shipping `core/version.py`.
- No UI redesign.


---
_Generated by [Claude Code](https://claude.ai/code/session_011AJ8j724GZmycm3Tpy8ejY)_