### PR TITLE
Stability pass: dedupe log/path helpers, harden setup subprocess

### DIFF
--- a/src/Auryn.py
+++ b/src/Auryn.py
@@ -323,12 +323,12 @@ def resolve_config_dir():
     streamrip uses click.get_app_dir("streamrip"): on Windows that is
     %APPDATA%\\streamrip, and on Linux it is $XDG_CONFIG_HOME/streamrip
     (defaulting to ~/.config/streamrip).
+
+    Delegates to core.tidal_auth.streamrip_config_dir so this path has a
+    single source of truth shared by the app, ``--doctor``, the preflight
+    checks and the unit tests (previously this logic was duplicated here).
     """
-    if IS_WINDOWS:
-        base = os.environ.get("APPDATA") or os.path.expanduser("~")
-        return os.path.join(base, "streamrip")
-    xdg = os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
-    return os.path.join(xdg, "streamrip")
+    return tidal_auth.streamrip_config_dir()
 
 
 def toml_escape(value):
@@ -1560,8 +1560,16 @@ class AurynApp:
         cfg_path = os.path.join(resolve_config_dir(), "config.toml")
         if not os.path.exists(cfg_path):
             if auto_fix and rip_cmd:
+                creationflags = (getattr(subprocess, "CREATE_NO_WINDOW", 0)
+                                 if IS_WINDOWS else 0)
                 try:
-                    result = subprocess.run(rip_cmd + ["config", "reset"], capture_output=True, text=True)
+                    # stdin=DEVNULL + timeout so a streamrip prompt can never
+                    # block the GTK thread; CREATE_NO_WINDOW avoids a console
+                    # flash on Windows (mirrors _ensure_streamrip_config).
+                    result = subprocess.run(
+                        rip_cmd + ["config", "reset"],
+                        capture_output=True, text=True, timeout=30,
+                        stdin=subprocess.DEVNULL, creationflags=creationflags)
                     if result.returncode != 0:
                         issues.append("Unable to generate streamrip config automatically.")
                 except Exception:
@@ -2056,9 +2064,7 @@ class AurynApp:
 
             while "\n" in buf:
                 line, buf = buf.split("\n", 1)
-                clean = re.sub(r'\x1b\[[0-9;]*[mGKHF]', '', line)
-                clean = re.sub(r'\x1b\][^\x07]*\x07', '', clean)
-                clean = re.sub(r'\r', '', clean)
+                clean = log_format.clean_stream_line(line)
                 if clean.strip():
                     GLib.idle_add(self._parse_line, clean + "\n")
                     if re.search(r'Track Download Done', clean, re.I):
@@ -2106,9 +2112,7 @@ class AurynApp:
 
         try:
             for line in self._process.stdout:
-                clean = re.sub(r'\x1b\[[0-9;]*[mGKHF]', '', line)
-                clean = re.sub(r'\x1b\][^\x07]*\x07', '', clean)
-                clean = clean.replace('\r', '')
+                clean = log_format.clean_stream_line(line)
                 if not clean.strip():
                     continue
                 if not clean.endswith("\n"):
@@ -3763,9 +3767,7 @@ class AurynApp:
                     for raw in proc.stdout:
                         if stop.is_set():
                             break
-                        clean = re.sub(r'\x1b\[[0-9;]*[mGKHF]', '', raw)
-                        clean = re.sub(r'\x1b\][^\x07]*\x07', '', clean)
-                        clean = clean.replace('\r', '')
+                        clean = log_format.clean_stream_line(raw)
                         clean = self._scrub_secrets(clean)
                         if not clean.strip():
                             continue
@@ -4395,9 +4397,8 @@ class AurynApp:
         buf_io = io.StringIO()
         with contextlib.redirect_stdout(buf_io), contextlib.redirect_stderr(buf_io):
             try:
-                ok = run_doctor(verbose=True)
+                run_doctor(verbose=True)
             except Exception as exc:
-                ok = False
                 print(f"FAIL  Diagnostics raised an exception: {exc}")
         output = buf_io.getvalue() or "(no output)"
         cfg_path = self._streamrip_config_path()

--- a/src/core/log_format.py
+++ b/src/core/log_format.py
@@ -75,6 +75,36 @@ def sanitize_log_text(text):
     return ''.join(out)
 
 
+# ── Parse-time line cleanup ───────────────────────────────────────────
+#
+# The download / TIDAL-login output pumps strip a small, fixed set of
+# terminal escapes from each raw streamrip line *before* matching it for
+# progress / title / speed signals, so the parsing regexes anchor on the
+# real message. This is intentionally lighter than sanitize_log_text (the
+# fuller display-time pass that still runs afterwards): it only removes
+# the SGR-colour / cursor CSI sequences with a final byte in "mGKHF", OSC
+# sequences terminated by BEL, and carriage returns. Defined once here so
+# the three pumps share a single implementation instead of re-coding it.
+_STREAM_CSI_RE = re.compile(r'\x1b\[[0-9;]*[mGKHF]')
+_STREAM_OSC_RE = re.compile(r'\x1b\][^\x07]*\x07')
+
+
+def clean_stream_line(line):
+    """Strip terminal colour/cursor escapes and carriage returns from *line*.
+
+    Returns the cleaned line (without altering its newline, if any) so the
+    progress parsers see plain text. Tolerates ``None`` / non-string input
+    by returning ``""`` rather than raising, so a pump can never crash on a
+    malformed read.
+    """
+    if not line:
+        return ""
+    s = line if isinstance(line, str) else str(line)
+    s = _STREAM_CSI_RE.sub('', s)
+    s = _STREAM_OSC_RE.sub('', s)
+    return s.replace('\r', '')
+
+
 # Soft-wrap width tuned to the visible columns of the log panel at the
 # default window size. GTK's own word-wrap handles paragraphs with
 # whitespace; this helper exists for unbroken paths / URLs / traceback

--- a/tests/test_log_format.py
+++ b/tests/test_log_format.py
@@ -59,6 +59,62 @@ def test_sanitize_preserves_unicode_emoji_and_paths():
     assert lf.sanitize_log_text(src) == src
 
 
+# ── clean_stream_line ─────────────────────────────────────────────────
+#
+# The download / TIDAL-login pumps pre-clean each raw streamrip line with
+# this helper before parsing it for progress signals. These tests pin the
+# exact behaviour the pumps historically open-coded inline so the shared
+# extraction stays byte-for-byte compatible with the protected pipeline.
+
+def _legacy_clean(line):
+    """The exact inline cleanup the three output pumps used before the
+    helper was extracted — used to assert equivalence."""
+    import re
+    clean = re.sub(r'\x1b\[[0-9;]*[mGKHF]', '', line)
+    clean = re.sub(r'\x1b\][^\x07]*\x07', '', clean)
+    return clean.replace('\r', '')
+
+
+def test_clean_stream_line_empty_or_none_returns_empty():
+    assert lf.clean_stream_line("") == ""
+    assert lf.clean_stream_line(None) == ""
+
+
+def test_clean_stream_line_strips_sgr_colour_codes():
+    assert lf.clean_stream_line("\x1b[31mERROR\x1b[0m here") == "ERROR here"
+
+
+def test_clean_stream_line_strips_cursor_and_clear_codes():
+    # CSI sequences ending in G / K / H / F are cursor / clear-line codes.
+    assert lf.clean_stream_line("\x1b[2K\x1b[1Gprogress") == "progress"
+
+
+def test_clean_stream_line_strips_osc_title_sequence():
+    assert lf.clean_stream_line("\x1b]0;window title\x07real text") == "real text"
+
+
+def test_clean_stream_line_removes_all_carriage_returns():
+    assert lf.clean_stream_line("a\rb\r\nc") == "ab\nc"
+
+
+def test_clean_stream_line_preserves_trailing_newline_and_unicode():
+    src = "Downloading 'Café — Track'\n"
+    assert lf.clean_stream_line(src) == src
+
+
+def test_clean_stream_line_matches_legacy_inline_behaviour():
+    samples = [
+        "\x1b[32mINFO\x1b[0m  Track Download Done\r\n",
+        "\x1b[2K\rDownloading track 'Hello' 1.23 MB/s",
+        "\x1b]0;rip\x07ERROR  Error downloading track: list index out of range\n",
+        "plain line, no escapes\n",
+        "",
+        "\r\n",
+    ]
+    for s in samples:
+        assert lf.clean_stream_line(s) == _legacy_clean(s)
+
+
 # ── wrap_long_line ────────────────────────────────────────────────────
 
 def test_wrap_short_line_unchanged():


### PR DESCRIPTION
## Summary

A careful, **small and focused stability/maintenance pass**. The goal was to find and fix low-risk issues, reduce duplication, and add test coverage **without changing any working behaviour**. No download command, provider behaviour, packaging, UI design, branding, or right-side metadata-panel logic is touched.

Net diff: **+104 / −17** across 3 files (1 app file, 1 core helper, 1 test file).

---

## Audit summary

### What was checked
I read the whole codebase with the protected areas in mind: `src/Auryn.py` (~4.6k lines) and every `src/core/*` module, plus the three CI workflows and the Debian/RPM/Windows packaging. Specifically inspected each area requested:

- streamrip executable detection (`core/streamrip_exec.py`) — robust, multi-call Windows path well handled
- Windows / Linux path handling and the streamrip **config-path handling** — *found duplication* (fixed)
- Deezer setup/status validation (`core/deezer.py`), TIDAL experimental auth (`core/tidal_auth.py`) — solid, secret-safe
- subprocess environment handling (UTF-8 forcing, `CREATE_NO_WINDOW`, `stdin=DEVNULL`) — *found one inconsistent call* (fixed)
- UTF-8 / encoding handling and **log parsing / error classification** — *found triplicated inline cleanup* (fixed)
- download final-status detection (`core/streamrip_status.py`), diagnostics/doctor output, release/version display, queue/history, app startup checks — all reviewed, no changes needed

### What was found
1. **Duplicated logic** — the ANSI/cursor/CR line-cleanup that pre-processes each raw streamrip line was copy-pasted in **three** output pumps (Linux PTY, Windows, TIDAL-login reader).
2. **Duplicated logic** — streamrip's config directory was resolved by two independent implementations (`resolve_config_dir()` in the app vs. `core.tidal_auth.streamrip_config_dir()`); they happened to agree, but a future edit to one could silently diverge so `--doctor`/preflight check a different file than the app uses.
3. **Fragile subprocess** — the Setup → **Auto-fix** `rip config reset` call (runs on the GTK main thread) lacked `stdin=DEVNULL`, a `timeout`, and `CREATE_NO_WINDOW`, so a streamrip prompt could freeze the UI and Windows would flash a console window. Its sibling `_ensure_streamrip_config` already does this correctly.
4. **Lint** — one genuine `F841` (assigned-but-unused `ok`) in the diagnostics dialog.

### What was fixed (all low-risk)
- **Extracted `core.log_format.clean_stream_line()`** and used it in all three pumps. Proven **byte-identical** to the old inline code via an equivalence unit test **and a 20,000-case fuzz check** — so the protected download/parse pipeline is unchanged, only de-duplicated and now unit-tested. The helper also tolerates `None`/non-str input instead of raising.
- **`resolve_config_dir()` now delegates** to `core.tidal_auth.streamrip_config_dir()` (single source of truth). Verified the resolved path is identical to the previous formula.
- **Hardened the Auto-fix subprocess** with `stdin=DEVNULL`, `timeout=30`, and `CREATE_NO_WINDOW` (mirrors `_ensure_streamrip_config`).
- **Removed the unused `ok`** in the diagnostics dialog (behaviour unchanged; resolves the only real `F841`).

### Intentionally left for a future PR (not done here)
These are larger or higher-risk and were **documented, not implemented**, to keep this PR safe:
- **Config-writer consolidation** — `Auryn._write_streamrip_section` and `tidal_auth.apply_streamrip_config_updates` overlap heavily; the former lacks the `[tidal]`-protection guard and the `os.fsync` durability the latter has. Worth unifying behind the core writer (with alias support), but it touches credential writing and needs its own focused PR + tests.
- **`toml_escape` duplication** — the app-level `toml_escape` re-implements `tidal_auth._toml_escape` and (unlike core) doesn't `str()`-cast; harmless today because callers always pass strings.
- **CI: `pytest || true`** in `python-app.yml` means tests don't gate merges. Making tests actually fail CI would be a real reliability win but should be a deliberate, separate change.
- The `_parse_line` ANSI strip only removes CSI finals in `mGKHF`; cursor-movement codes (e.g. `…[1A`) can leak to the parser. Display-time `sanitize_log_text` already handles them; widening the parse-time strip is a behaviour change best done with dedicated tests.

---

## Validation

- `python3 -m py_compile src/Auryn.py src/core/*.py` → clean
- `pytest` → **232 passed** (was 225; **+7** new `clean_stream_line` tests)
- `flake8` critical gate (`E9,F63,F7,F82`) → **0**
- `clean_stream_line` equivalence: explicit cases + **20,000 fuzzed inputs**, 0 mismatches vs. the legacy inline pipeline
- `resolve_config_dir()` smoke-test: identical to core + legacy formula
- `--version` and `--doctor` CLI paths exercised (GTK is absent in CI, which `--doctor` reports as designed)

---

## Risks / notes
- **Low risk overall.** The only edits to the download/login pumps replace three identical inline statements with one call that is provably byte-identical (fuzzed). Subprocess args, line splitting, parsing branches, and `GLib.idle_add` marshalling are unchanged.
- No new dependencies. No packaging/workflow changes. No UI/CSS/branding/logo changes.

## Confirmation
- **Download logic was not intentionally changed** — no change to the streamrip command (`rip … url <url>`), env setup, `Popen`/PTY handling, quality clamping, or provider classification.
- **The right-side cover/metadata panel was not changed** — `_apply_deezer_meta`, `_apply_qobuz_meta`, `_set_meta`, and `core/metadata.py` are untouched.
- Deezer/Qobuz downloads, Windows support, and Linux packaging paths are all preserved; logs/diagnostics/setup remain available.

🤖 Draft PR — generated during a stability review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYtzpRfqgQXo1qcuXvYYmT)_